### PR TITLE
Feature/#590/use cli ini file.  Closes #590.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ useDiskCaching | Indicates whether disk caching is used. | Optional.  Will defau
 
 ## Credentials
 
-We recommend that you authorize your machine using the cloco-bash tool, but you can set the cloco credentials via the options.  You can generate API credentials via the cloco admin UI or via the API.  Please ensure that the credentials are kept safe.
+We recommend that you set machine credentials using the cloco-cli tool, but you can set the cloco credentials via the options.  You can generate API credentials via the cloco admin UI or via the API.  Please ensure that the credentials are kept safe.
+
+To set credentials via cloco-cli
+
+    $ cloco init --key $CLOCO_CLIENT_KEY --secret $CLOCO_CLIENT_SECRET
+
+Alternatively, you can pass credentials into the cloco-node-client as follows:
 
 ````
 // initialize the credentials if supplied via environment variables.
@@ -166,6 +172,7 @@ Run the unit tests with jasmine:
 - `0.3.0` Non-breaking update, aligns AES encryption with openssl.
 - `0.3.1` Non-breaking update, additional test coverage and small fixes.
 - `0.4.0` Non-breaking update, add local disk caching of configuration.
+- `0.5.0` Major update, uses the ini file format of the cloco-cli tool.
 
 # License
 Copyright (c) 2016 345 Systems LLP

--- a/README.md
+++ b/README.md
@@ -175,5 +175,5 @@ Run the unit tests with jasmine:
 - `0.5.0` Major update, uses the ini file format of the cloco-cli tool.
 
 # License
-Copyright (c) 2016 345 Systems LLP
+Copyright (c) 2016-2017 345 Systems LLP
 Licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Run the unit tests with jasmine:
 
 `npm run test`
 
+# Contributing
+
+We welcome contributions from the community.  Feature requests and bug reports should be raised as issues on GitHub.  If you wish to contribute a fix please fork, make your changes and issue a PR.
+
 # Version Notes
 - `0.1.0` Initial version, supports read-only access to a configuration object.
 - `0.1.1` Minor fixes.

--- a/README.md
+++ b/README.md
@@ -167,17 +167,6 @@ Run the unit tests with jasmine:
 
 We welcome contributions from the community.  Feature requests and bug reports should be raised as issues on GitHub.  If you wish to contribute a fix please fork, make your changes and issue a PR.
 
-# Version Notes
-- `0.1.0` Initial version, supports read-only access to a configuration object.
-- `0.1.1` Minor fixes.
-- `0.1.2` Fixes to allow the code to work with cloco-node-example.
-- `0.1.3` Clean up of build files, removes final console.logs.
-- `0.2.0` Major breaking rebuild.  Aligns with V1.0.0 cloco API.
-- `0.3.0` Non-breaking update, aligns AES encryption with openssl.
-- `0.3.1` Non-breaking update, additional test coverage and small fixes.
-- `0.4.0` Non-breaking update, add local disk caching of configuration.
-- `0.5.0` Major update, uses the ini file format of the cloco-cli tool.
-
 # License
 Copyright (c) 2016-2017 345 Systems LLP
 Licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A cloco client for distribution as an NPM package, for incorporating into NodeJS applications.  
 
+## Documentation
+
+The documentation for cloco is available on GitHub pages [https://cloudconfig.github.io/cloco-docs/](https://cloudconfig.github.io/cloco-docs/).
+
 ## Prerequisites
 
 The following global prerequisites must exist:

--- a/lib/api-client.d.ts
+++ b/lib/api-client.d.ts
@@ -35,12 +35,6 @@ export declare class ApiClient {
      * @param  {IOptions}          options The initialization options.
      * @return {Promise<AccessTokenResponse>}         A promise of the access token.
      */
-    private static getAccessTokenFromRefreshToken(options);
-    /**
-     * Refreshes the bearer token.
-     * @param  {IOptions}          options The initialization options.
-     * @return {Promise<AccessTokenResponse>}         A promise of the access token.
-     */
     private static getAccessTokenFromClientCredentials(options);
     /**
      * Gets the restify options based on the settings.

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -16,7 +16,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 const restify = require("restify");
 const logger_1 = require("./logging/logger");
 const jwt_decoder_1 = require("./jwt-decoder");
-const settings_1 = require("./settings");
 const token_request_1 = require("./types/token-request");
 const api_error_1 = require("./types/api-error");
 /**
@@ -137,17 +136,11 @@ class ApiClient {
         return __awaiter(this, void 0, void 0, function* () {
             logger_1.Logger.log.debug(`ApiClient.checkBearerToken: start.`);
             try {
-                if (jwt_decoder_1.JwtDecoder.bearerTokenExpired(options.tokens.accessToken)) {
+                if (!options.tokens.accessToken || jwt_decoder_1.JwtDecoder.bearerTokenExpired(options.tokens.accessToken)) {
                     logger_1.Logger.log.debug(`ApiClient.checkBearerToken: bearer token has expired and will be refreshed.`);
                     let response;
-                    if (options.credentials) {
-                        response = yield ApiClient.getAccessTokenFromClientCredentials(options);
-                    }
-                    else {
-                        response = yield ApiClient.getAccessTokenFromRefreshToken(options);
-                    }
+                    response = yield ApiClient.getAccessTokenFromClientCredentials(options);
                     options.tokens.accessToken = response.access_token;
-                    settings_1.Settings.storeBearerToken(response.access_token);
                 }
             }
             catch (e) {
@@ -155,35 +148,6 @@ class ApiClient {
                 throw e;
             }
             logger_1.Logger.log.debug(`ApiClient.checkBearerToken: complete.`);
-        });
-    }
-    /**
-     * Refreshes the bearer token.
-     * @param  {IOptions}          options The initialization options.
-     * @return {Promise<AccessTokenResponse>}         A promise of the access token.
-     */
-    static getAccessTokenFromRefreshToken(options) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger_1.Logger.log.debug("ApiClient.getAccessTokenFromRefreshToken: start");
-            // initialise the restify client.
-            let client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
-            let path = `/oauth/token`;
-            let body = new token_request_1.TokenRequest();
-            body.grant_type = "refresh_token";
-            body.refresh_token = options.tokens.refreshToken;
-            logger_1.Logger.log.debug("ApiClient.getAccessTokenFromRefreshToken: Calling API", { url: options.url }, { path: path });
-            return new Promise(function (resolve, reject) {
-                client.post(path, body, function (err, req, res, obj) {
-                    if (err) {
-                        logger_1.Logger.log.error(err, "ApiClient.getAccessTokenFromRefreshToken: Error getting access token.");
-                        reject(err);
-                    }
-                    else {
-                        logger_1.Logger.log.debug("ApiClient.getAccessTokenFromRefreshToken: Access token response received.");
-                        resolve(obj);
-                    }
-                });
-            });
         });
     }
     /**

--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -61,7 +61,7 @@ class Cache {
         logger_1.Logger.log.debug(`Cache.addItem: start. key: '${key}', revision: '${revision}'`);
         let existing = this.get(key);
         if (!existing || existing.revision < revision) {
-            logger_1.Logger.log.debug(`Cache.addItem: new revision '${revision}' detected, adding to cache.`);
+            logger_1.Logger.log.info(`Cache.addItem: new revision '${revision}' detected, adding to cache.`);
             let cacheItem = new cache_item_1.CacheItem();
             cacheItem.key = key;
             cacheItem.value = value;
@@ -88,7 +88,7 @@ class Cache {
                 if (this.items[i].key === key) {
                     logger_1.Logger.log.debug(`Cache.get: Item '${key}' located in items array.  Returning....`);
                     if (this.items[i].isExpired()) {
-                        logger_1.Logger.log.info(`Cache.get: Item '${key}' has expired.`);
+                        logger_1.Logger.log.debug(`Cache.get: Item '${key}' has expired.`);
                     }
                     return this.items[i];
                 }

--- a/lib/cloco-client.js
+++ b/lib/cloco-client.js
@@ -40,6 +40,8 @@ class ClocoClient {
             this.onCacheExpired.subscribe((client, item) => {
                 this.loadConfigurationObjectWrapperFromApi(item.key);
             });
+            // ensure the local cache folder is available
+            file_system_1.FileSystem.ensureDirectory(`${file_system_1.FileSystem.getUserHome()}/.cloco/cache`);
             // set default values.
             settings_1.Settings.setDefaults(this.options);
         }
@@ -326,6 +328,7 @@ class ClocoClient {
         if (this.options.useEncryption) {
             logger_1.Logger.log.debug(`ClocoClient.decryptAndDecode: decrypting object '${wrapper.objectIdentifier}'.`);
             let decrypted = this.options.encryptor.decrypt(wrapper.configurationData);
+            // tslint:disable-next-line:max-line-length
             logger_1.Logger.log.debug(`ClocoClient.decryptAndDecode: decoding object '${wrapper.objectIdentifier}' to format '${configObject.format}'.`);
             let encoder = encoding_1.Encoding.getEncoder(configObject.format);
             data = encoder.decode(decrypted);

--- a/lib/file-system.d.ts
+++ b/lib/file-system.d.ts
@@ -18,6 +18,10 @@ export declare class FileSystem {
      */
     static writeFile(filename: string, data: string): Promise<void>;
     /**
+     * Ensures that the local config directories exist.
+     */
+    static ensureDirectory(path: string): void;
+    /**
      * Returns the user home path.
      * @return {string} The user home path.
      */

--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -63,6 +63,17 @@ class FileSystem {
         });
     }
     /**
+     * Ensures that the local config directories exist.
+     */
+    static ensureDirectory(path) {
+        logger_1.Logger.log.debug("FileSystem.ensureDirectory: start.");
+        if (!fs.existsSync(path)) {
+            logger_1.Logger.log.debug(`FileSystem.ensureDirectory: creating local folder '${path}'.`);
+            fs.mkdir(path);
+        }
+        logger_1.Logger.log.debug("FileSystem.ensureDirectory: end.");
+    }
+    /**
      * Returns the user home path.
      * @return {string} The user home path.
      */

--- a/lib/settings.d.ts
+++ b/lib/settings.d.ts
@@ -5,48 +5,8 @@ export declare class Settings {
      */
     static setDefaults(options: IOptions): void;
     /**
-     * Reads the bearer token from the local config store.
-     * @return {string} The bearer token.
+     * Returns the path to the local ini file created by cloco-cli
+     * @return {string} [description]
      */
-    static getBearerToken(): string;
-    /**
-     * Stores the bearer token in the local config store.
-     * @param {string} token The bearer token.
-     */
-    static storeBearerToken(token: string): Promise<void>;
-    /**
-     * Gets the refresh token from the local config store.
-     * @return {string} The refresh token.
-     */
-    static getRefreshToken(): string;
-    /**
-     * Gets the default subscription from the local config store.
-     * @return {string} The subscription id.
-     */
-    static getDefaultSubscription(): string;
-    /**
-     * Gets the default application from the local config store.
-     * @return {string} The application id.
-     */
-    static getDefaultApplication(): string;
-    /**
-     * Gets the default environment from the local config store.
-     * @return {string} The environment id.
-     */
-    static getDefaultEnvironment(): string;
-    /**
-     * Gets the default cloco API url from the local store (for on-prem installations).
-     * @return {string} The default cloco API url.
-     */
-    static getDefaultUrl(): string;
-    /**
-     * Reads the content from a file.
-     * @param  {string} path The path of the file.
-     * @return {string}      The contents of the file.
-     */
-    private static readFileContent(path);
-    /**
-     * Ensures that the local config directories exist.
-     */
-    private static ensureLocalDirs();
+    private static getConfigFilePath();
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,12 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
-    });
-};
 /**
  *   settings.ts
  *   Copyright (c) 345 Systems LLP 2016, all rights reserved.
@@ -14,10 +6,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
  *   Static access to local cloco settings.
  */
 const fs = require("fs");
+const ini = require("ini");
 const file_system_1 = require("./file-system");
 const logger_1 = require("./logging/logger");
 const passthrough_encryptor_1 = require("./encryption/passthrough-encryptor");
 const settings_error_1 = require("./settings-error");
+const credentials_1 = require("./types/credentials");
 const tokens_1 = require("./types/tokens");
 class Settings {
     /**
@@ -28,120 +22,50 @@ class Settings {
         // default the encryptor to the passthrough encryptor if not set.
         options.useEncryption = options.encryptor ? true : false;
         options.encryptor = options.encryptor || new passthrough_encryptor_1.PassthroughEncryptor();
-        // load the url from config else use the default cloco one.
-        options.url = options.url || Settings.getDefaultUrl() || "https://api.cloco.io";
-        // ensure that a subscription is set, either globally or on the options.
-        options.subscription = options.subscription || Settings.getDefaultSubscription();
+        // check for local settings
+        if (fs.existsSync(Settings.getConfigFilePath())) {
+            let config = ini.parse(Settings.getConfigFilePath());
+            // load the url from config else use the default cloco one.
+            options.url = options.url || config.settings.url;
+            options.subscription = options.subscription || config.preferences.subscription;
+            options.application = options.application || config.preferences.application;
+            options.environment = options.environment || config.preferences.environment;
+            if (!options.credentials) {
+                options.credentials = new credentials_1.Credentials();
+                options.credentials.key = config.credentials.cloco_client_key;
+                options.credentials.secret = config.credentials.cloco_client_secret;
+            }
+            if (!options.tokens) {
+                options.tokens = new tokens_1.Tokens();
+            }
+        }
+        // if url not set then use the default cloco url.
+        options.url = options.url || "https://api.cloco.io";
+        // set the interval for checking the cache expiry.
+        options.cacheCheckInterval = options.cacheCheckInterval || 60000;
+        // ensure that a subscription is set.
         if (!options.subscription) {
             throw new settings_error_1.SettingsError("Could not load setting: subscription.", "options.subscription");
         }
-        // ensure that an application is set, either globally or on the options.
-        options.application = options.application || Settings.getDefaultApplication();
+        // ensure that an application is set.
         if (!options.application) {
             throw new settings_error_1.SettingsError("Could not load setting: application.", "options.application");
         }
-        // ensure that an environment is set, either globally or on the options.
-        options.environment = options.environment || Settings.getDefaultEnvironment();
+        // ensure that an environment is set.
         if (!options.environment) {
             throw new settings_error_1.SettingsError("Could not load setting: environment.", "options.environment");
         }
-        // set the interval for checking the cache expiry.
-        options.cacheCheckInterval = options.cacheCheckInterval || 60000;
-        // check the credentials and load the tokens if appropriate.
-        if (!options.tokens) {
-            options.tokens = new tokens_1.Tokens();
-            options.tokens.accessToken = Settings.getBearerToken();
-            options.tokens.refreshToken = Settings.getRefreshToken();
-        }
-        if (!options.credentials) {
-            if (!options.tokens.accessToken) {
-                throw new settings_error_1.SettingsError("Could not load bearer token.", "options.tokens.accessToken");
-            }
-            if (!options.tokens.refreshToken) {
-                throw new settings_error_1.SettingsError("Could not load refresh token.", "options.tokens.refreshToken");
-            }
+        if (!options.credentials || !options.credentials.key || !options.credentials.secret) {
+            throw new settings_error_1.SettingsError("No credentials available", "options.credentials");
         }
         logger_1.Logger.log.debug("Settings.setDefaults: end.");
     }
     /**
-     * Reads the bearer token from the local config store.
-     * @return {string} The bearer token.
+     * Returns the path to the local ini file created by cloco-cli
+     * @return {string} [description]
      */
-    static getBearerToken() {
-        return Settings.readFileContent(`${file_system_1.FileSystem.getUserHome()}/.cloco/config/cloco_token`);
-    }
-    /**
-     * Stores the bearer token in the local config store.
-     * @param {string} token The bearer token.
-     */
-    static storeBearerToken(token) {
-        return __awaiter(this, void 0, void 0, function* () {
-            yield file_system_1.FileSystem.writeFile(`${file_system_1.FileSystem.getUserHome()}/.cloco/config/cloco_token`, token);
-        });
-    }
-    /**
-     * Gets the refresh token from the local config store.
-     * @return {string} The refresh token.
-     */
-    static getRefreshToken() {
-        return Settings.readFileContent(`${file_system_1.FileSystem.getUserHome()}/.cloco/config/cloco_refresh_token`);
-    }
-    /**
-     * Gets the default subscription from the local config store.
-     * @return {string} The subscription id.
-     */
-    static getDefaultSubscription() {
-        return Settings.readFileContent(`${file_system_1.FileSystem.getUserHome()}/.cloco/config/subscription`);
-    }
-    /**
-     * Gets the default application from the local config store.
-     * @return {string} The application id.
-     */
-    static getDefaultApplication() {
-        return Settings.readFileContent(`${file_system_1.FileSystem.getUserHome()}/.cloco/config/application`);
-    }
-    /**
-     * Gets the default environment from the local config store.
-     * @return {string} The environment id.
-     */
-    static getDefaultEnvironment() {
-        return Settings.readFileContent(`${file_system_1.FileSystem.getUserHome()}/.cloco/config/environment`);
-    }
-    /**
-     * Gets the default cloco API url from the local store (for on-prem installations).
-     * @return {string} The default cloco API url.
-     */
-    static getDefaultUrl() {
-        return Settings.readFileContent(`${file_system_1.FileSystem.getUserHome()}/.cloco/config/url`);
-    }
-    /**
-     * Reads the content from a file.
-     * @param  {string} path The path of the file.
-     * @return {string}      The contents of the file.
-     */
-    static readFileContent(path) {
-        Settings.ensureLocalDirs();
-        if (fs.existsSync(path)) {
-            let content = fs.readFileSync(path, "utf8");
-            content = content.replace(/\n$/, "");
-            return content;
-        }
-        else {
-            return undefined;
-        }
-    }
-    /**
-     * Ensures that the local config directories exist.
-     */
-    static ensureLocalDirs() {
-        let path = `${file_system_1.FileSystem.getUserHome()}/.cloco/config`;
-        if (!fs.existsSync(path)) {
-            fs.mkdir(path);
-        }
-        path = `${file_system_1.FileSystem.getUserHome()}/.cloco/cache`;
-        if (!fs.existsSync(path)) {
-            fs.mkdir(path);
-        }
+    static getConfigFilePath() {
+        return `${file_system_1.FileSystem.getUserHome()}/.cloco/configuration`;
     }
 }
 exports.Settings = Settings;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -24,7 +24,7 @@ class Settings {
         options.encryptor = options.encryptor || new passthrough_encryptor_1.PassthroughEncryptor();
         // check for local settings
         if (fs.existsSync(Settings.getConfigFilePath())) {
-            let config = ini.parse(Settings.getConfigFilePath());
+            let config = ini.parse(fs.readFileSync(Settings.getConfigFilePath(), "utf-8"));
             // load the url from config else use the default cloco one.
             options.url = options.url || config.settings.url;
             options.subscription = options.subscription || config.preferences.subscription;

--- a/lib/types/clocoapp.d.ts
+++ b/lib/types/clocoapp.d.ts
@@ -144,7 +144,7 @@ export declare class ClocoAppCoreDetails {
      * Indicates whether this is the default app in the subscription.
      * @type {boolean}
      */
-    isDefault: boolean;
+    isFavorite: boolean;
 }
 /**
  *   class ConfigObjectHeader

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   },
   "homepage": "https://github.com/cloudconfig/cloco-node-client#readme",
   "dependencies": {
+    "ini": "^1.3.4",
     "jsonwebtoken": "^7.2.1",
     "restify": "^4.1.1",
     "rxjs": "^5.0.0-rc.3"
   },
   "devDependencies": {
     "@types/bunyan": "0.0.33",
+    "@types/ini": "^1.3.29",
     "@types/jasmine": "^2.5.38",
     "@types/jsonwebtoken": "^7.2.0",
     "@types/node": "^6.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloco-node-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A cloco client for distribution as an NPM package.",
   "main": "lib/index.js",
   "typings": "lib/index",

--- a/src/api-client.spec.ts
+++ b/src/api-client.spec.ts
@@ -11,402 +11,407 @@ import { Logger } from "./logging/logger";
 
 describe("ApiClient unit tests", function(): void {
 
-  let options: IOptions;
-  let requestedPath: string;
+    let options: IOptions;
+    let requestedPath: string;
 
-  beforeAll(function(done: () => void): void {
-    Logger.init({});
-    done();
-  });
-
-  beforeEach(function(done: () => void): void {
-    options = {};
-    options.tokens = { accessToken: "", refreshToken: "refresh-token" };
-    options.url = "https://test.api.cloco.io";
-    options.subscription = "subscription";
-    options.application = "application";
-    options.environment = "test";
-
-    let generator: JwtGenerator = new JwtGenerator();
-    generator.generateJwt("A1234", "some-user")
-      .then((jwt: string) => {
-        options.tokens.accessToken = jwt;
+    beforeAll(function(done: () => void): void {
+        Logger.init({});
         done();
-      });
-  });
+    });
 
-  it("getApplication: successful happy path call to api with valid bearer token.", function(done: () => void): void {
+    beforeEach(function(done: () => void): void {
+        options = {};
+        options.tokens = { accessToken: "", refreshToken: "" };
+        options.url = "https://test.api.cloco.io";
+        options.subscription = "subscription";
+        options.application = "application";
+        options.environment = "test";
 
-      let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.get = (path: string, callback: (err: Error, req: restify.Request, res: restify.Response, obj: ClocoApp) => void): void => {
-              requestedPath = path;
-              let app: ClocoApp = new ClocoApp();
-              app.applicationIdentifier = "unit-test-app";
-              callback(undefined, undefined, undefined, app);
-          };
-          return client;
-      });
+        let generator: JwtGenerator = new JwtGenerator();
+        generator.generateJwt("A1234", "some-user")
+            .then((jwt: string) => {
+                options.tokens.accessToken = jwt;
+                done();
+            });
+    });
 
-      ApiClient.getApplication(options)
-        .then((app: ClocoApp) => {
-          expect(app).toBeTruthy();
-          expect(app.applicationIdentifier).toEqual("unit-test-app");
-          expect(requestedPath).toEqual("/subscription/applications/application");
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("no error expected.");
-          done();
+    it("getApplication: successful happy path call to api with valid bearer token.", function(done: () => void): void {
+
+        let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            // tslint:disable-next-line:max-line-length
+            client.get = (path: string, callback: (err: Error, req: restify.Request, res: restify.Response, obj: ClocoApp) => void): void => {
+                requestedPath = path;
+                let app: ClocoApp = new ClocoApp();
+                app.applicationIdentifier = "unit-test-app";
+                callback(undefined, undefined, undefined, app);
+            };
+            return client;
         });
-  });
 
-  it("getApplication: call to api errors, expect rejection of promise.", function(done: () => void): void {
+        ApiClient.getApplication(options)
+            .then((app: ClocoApp) => {
+                expect(app).toBeTruthy();
+                expect(app.applicationIdentifier).toEqual("unit-test-app");
+                expect(requestedPath).toEqual("/subscription/applications/application");
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("no error expected.");
+                done();
+            });
+    });
 
-      let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.get = (path: string, callback: (err: Error, req: restify.Request, res: restify.Response, obj: ClocoApp) => void): void => {
-              requestedPath = path;
-              let error: Error = new Error("unit-test-error");
-              callback(error, undefined, undefined, undefined);
-          };
-          return client;
-      });
+    it("getApplication: call to api errors, expect rejection of promise.", function(done: () => void): void {
 
-      ApiClient.getApplication(options)
-        .then((app: ClocoApp) => {
-          fail("error expected.");
-          done();
-        })
-        .catch((e: Error) => {
-          expect(e).toBeTruthy();
-          expect(e.message).toEqual("unit-test-error");
-          expect(requestedPath).toEqual("/subscription/applications/application");
-          done();
+        let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            // tslint:disable-next-line:max-line-length
+            client.get = (path: string, callback: (err: Error, req: restify.Request, res: restify.Response, obj: ClocoApp) => void): void => {
+                requestedPath = path;
+                let error: Error = new Error("unit-test-error");
+                callback(error, undefined, undefined, undefined);
+            };
+            return client;
         });
-  });
 
-  it("getConfigObject: successful happy path call to api with valid bearer token.", function(done: () => void): void {
+        ApiClient.getApplication(options)
+            .then((app: ClocoApp) => {
+                fail("error expected.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e).toBeTruthy();
+                expect(e.message).toEqual("unit-test-error");
+                expect(requestedPath).toEqual("/subscription/applications/application");
+                done();
+            });
+    });
 
-      let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.get = (path: string,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: ConfigObjectWrapper) => void): void => {
-              requestedPath = path;
-              let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
-              cob.objectIdentifier = "unit-test-cob";
-              callback(undefined, undefined, undefined, cob);
-          };
-          return client;
-      });
+    it("getConfigObject: successful happy path call to api with valid bearer token.", function(done: () => void): void {
 
-      ApiClient.getConfigObject(options, "objectId")
-        .then((cob: ConfigObjectWrapper) => {
-          expect(cob).toBeTruthy();
-          expect(cob.objectIdentifier).toEqual("unit-test-cob");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("no error expected.");
-          done();
+        let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.get = (path: string,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: ConfigObjectWrapper) => void): void => {
+                requestedPath = path;
+                let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
+                cob.objectIdentifier = "unit-test-cob";
+                callback(undefined, undefined, undefined, cob);
+            };
+            return client;
         });
-  });
 
-  it("getConfigObject: call to api errors, expect rejection of promise.", function(done: () => void): void {
+        ApiClient.getConfigObject(options, "objectId")
+            .then((cob: ConfigObjectWrapper) => {
+                expect(cob).toBeTruthy();
+                expect(cob.objectIdentifier).toEqual("unit-test-cob");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("no error expected.");
+                done();
+            });
+    });
 
-      let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.get = (path: string,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: ConfigObjectWrapper) => void): void => {
-              requestedPath = path;
-              let error: Error = new Error("unit-test-error");
-              callback(error, undefined, undefined, undefined);
-          };
-          return client;
-      });
+    it("getConfigObject: call to api errors, expect rejection of promise.", function(done: () => void): void {
 
-      ApiClient.getConfigObject(options, "objectId")
-        .then((app: ConfigObjectWrapper) => {
-          fail("error expected.");
-          done();
-        })
-        .catch((e: Error) => {
-          expect(e).toBeTruthy();
-          expect(e.message).toEqual("unit-test-error");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          done();
+        let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.get = (path: string,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: ConfigObjectWrapper) => void): void => {
+                requestedPath = path;
+                let error: Error = new Error("unit-test-error");
+                callback(error, undefined, undefined, undefined);
+            };
+            return client;
         });
-  });
 
-  it("putConfigObject: successful happy path call to api with valid bearer token, JSON object.", function(done: () => void): void {
+        ApiClient.getConfigObject(options, "objectId")
+            .then((app: ConfigObjectWrapper) => {
+                fail("error expected.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e).toBeTruthy();
+                expect(e.message).toEqual("unit-test-error");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                done();
+            });
+    });
 
-      let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.put = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              requestedPath = path;
-              let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
-              cob.objectIdentifier = "unit-test-cob";
-              callback(undefined, undefined, undefined, cob);
-          };
-          return client;
-      });
+    it("putConfigObject: successful happy path call to api with valid bearer token, JSON object.", function(done: () => void): void {
 
-      ApiClient.putConfigObject(options, "objectId", { objectType: "test" })
-        .then((cob: ConfigObjectWrapper) => {
-          expect(cob).toBeTruthy();
-          expect(cob.objectIdentifier).toEqual("unit-test-cob");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("no error expected.");
-          done();
+        let clientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.put = (path: string, body: any,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                requestedPath = path;
+                let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
+                cob.objectIdentifier = "unit-test-cob";
+                callback(undefined, undefined, undefined, cob);
+            };
+            return client;
         });
-  });
 
-  it("putConfigObject: successful happy path call to api with valid bearer token, string.", function(done: () => void): void {
+        ApiClient.putConfigObject(options, "objectId", { objectType: "test" })
+            .then((cob: ConfigObjectWrapper) => {
+                expect(cob).toBeTruthy();
+                expect(cob.objectIdentifier).toEqual("unit-test-cob");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("no error expected.");
+                done();
+            });
+    });
 
-      let clientSpy: jasmine.Spy = spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.put = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              requestedPath = path;
-              let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
-              cob.objectIdentifier = "unit-test-cob";
-              cob.configurationData = body;
-              callback(undefined, undefined, undefined, JSON.stringify(cob));
-          };
-          return client;
-      });
+    it("putConfigObject: successful happy path call to api with valid bearer token, string.", function(done: () => void): void {
 
-      ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
-        .then((cob: ConfigObjectWrapper) => {
-          expect(cob).toBeTruthy();
-          expect(cob.objectIdentifier).toEqual("unit-test-cob");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("no error expected.");
-          done();
+        let clientSpy: jasmine.Spy = spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.put = (path: string, body: any,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                requestedPath = path;
+                let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
+                cob.objectIdentifier = "unit-test-cob";
+                cob.configurationData = body;
+                callback(undefined, undefined, undefined, JSON.stringify(cob));
+            };
+            return client;
         });
-  });
 
-  it("putConfigObject: failed call to api with valid bearer token, string client, error.", function(done: () => void): void {
+        ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
+            .then((cob: ConfigObjectWrapper) => {
+                expect(cob).toBeTruthy();
+                expect(cob.objectIdentifier).toEqual("unit-test-cob");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("no error expected.");
+                done();
+            });
+    });
 
-      let clientSpy: jasmine.Spy = spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.put = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              requestedPath = path;
-              callback(new Error("unit-test-error"), undefined, undefined, undefined);
-          };
-          return client;
-      });
+    it("putConfigObject: failed call to api with valid bearer token, string client, error.", function(done: () => void): void {
 
-      ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
-      .then((app: ConfigObjectWrapper) => {
-        fail("error expected.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e).toBeTruthy();
-        expect(e.message).toEqual("unit-test-error");
-        expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-        done();
-      });
-  });
-
-  it("putConfigObject: bearer token expired, acquire new token, string client.", function(done: () => void): void {
-
-      // assign an expired jwt.
-      // tslint:disable-next-line:max-line-length
-      options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
-
-      let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.post = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              let response: any = { "access_token": "test-access-token" };
-              callback(undefined, undefined, undefined, response);
-          };
-          return client;
-      });
-
-      let stringClientSpy: jasmine.Spy =
-        spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.put = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              requestedPath = path;
-              let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
-              cob.objectIdentifier = "unit-test-cob";
-              cob.configurationData = body;
-              callback(undefined, undefined, undefined, JSON.stringify(cob));
-          };
-          return client;
-      });
-
-      ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
-        .then((cob: ConfigObjectWrapper) => {
-          expect(cob).toBeTruthy();
-          expect(cob.objectIdentifier).toEqual("unit-test-cob");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          expect(jsonClientSpy).toHaveBeenCalledTimes(1);
-          expect(stringClientSpy).toHaveBeenCalledTimes(1);
-          expect(options.tokens.accessToken).toEqual("test-access-token");
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("no error expected.");
-          done();
+        let clientSpy: jasmine.Spy = spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.put = (path: string, body: any,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                requestedPath = path;
+                callback(new Error("unit-test-error"), undefined, undefined, undefined);
+            };
+            return client;
         });
-  });
 
-  it("putConfigObject: bearer token expired, acquire new token, error acquiring token.", function(done: () => void): void {
+        ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
+            .then((app: ConfigObjectWrapper) => {
+                fail("error expected.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e).toBeTruthy();
+                expect(e.message).toEqual("unit-test-error");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                done();
+            });
+    });
 
-      // assign an expired jwt.
-      // tslint:disable-next-line:max-line-length
-      options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
+    it("putConfigObject: bearer token expired, acquire new token, string client.", function(done: () => void): void {
 
-      let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.post = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              callback(new Error("bearer-token-error"), undefined, undefined, undefined);
-          };
-          return client;
-      });
+        // assign an expired jwt.
+        // tslint:disable-next-line:max-line-length
+        options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
+        options.credentials = { key: "api-key", secret: "api-secret" };
 
-      let stringClientSpy: jasmine.Spy =
-        spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.put = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              requestedPath = path;
-              let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
-              cob.objectIdentifier = "unit-test-cob";
-              cob.configurationData = body;
-              callback(undefined, undefined, undefined, JSON.stringify(cob));
-          };
-          return client;
-      });
-
-      ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
-        .then((app: ConfigObjectWrapper) => {
-          fail("error expected.");
-          done();
-        })
-        .catch((e: Error) => {
-          expect(e).toBeTruthy();
-          expect(e.message).toEqual("bearer-token-error");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          expect(jsonClientSpy).toHaveBeenCalledTimes(1);
-          expect(stringClientSpy).toHaveBeenCalledTimes(0);
-          done();
+        let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.post = (path: string, body: any,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                let response: any = { "access_token": "test-access-token" };
+                callback(undefined, undefined, undefined, response);
+            };
+            return client;
         });
-  });
 
-  it("putConfigObject: bearer token expired, acquire new token from client credentials, string client.", function(done: () => void): void {
+        let stringClientSpy: jasmine.Spy =
+            spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+                let client: restify.Client = {} as restify.Client;
+                client.put = (path: string, body: any,
+                    callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                    requestedPath = path;
+                    let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
+                    cob.objectIdentifier = "unit-test-cob";
+                    cob.configurationData = body;
+                    callback(undefined, undefined, undefined, JSON.stringify(cob));
+                };
+                return client;
+            });
 
-      // assign an expired jwt.
-      // tslint:disable-next-line:max-line-length
-      options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
-      options.tokens.refreshToken = "";
-      options.credentials = { key: "key", secret: "secret" };
+        ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
+            .then((cob: ConfigObjectWrapper) => {
+                expect(cob).toBeTruthy();
+                expect(cob.objectIdentifier).toEqual("unit-test-cob");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                expect(jsonClientSpy).toHaveBeenCalledTimes(1);
+                expect(stringClientSpy).toHaveBeenCalledTimes(1);
+                expect(options.tokens.accessToken).toEqual("test-access-token");
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("no error expected.");
+                done();
+            });
+    });
 
-      let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.post = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              let response: any = { "access_token": "test-access-token" };
-              callback(undefined, undefined, undefined, response);
-          };
-          return client;
-      });
+    it("putConfigObject: bearer token expired, acquire new token, error acquiring token.", function(done: () => void): void {
 
-      let stringClientSpy: jasmine.Spy =
-        spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.put = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              requestedPath = path;
-              let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
-              cob.objectIdentifier = "unit-test-cob";
-              cob.configurationData = body;
-              callback(undefined, undefined, undefined, JSON.stringify(cob));
-          };
-          return client;
-      });
+        // assign an expired jwt.
+        // tslint:disable-next-line:max-line-length
+        options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
+        options.credentials = { key: "api-key", secret: "api-secret" };
 
-      ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
-        .then((cob: ConfigObjectWrapper) => {
-          expect(cob).toBeTruthy();
-          expect(cob.objectIdentifier).toEqual("unit-test-cob");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          expect(jsonClientSpy).toHaveBeenCalledTimes(1);
-          expect(stringClientSpy).toHaveBeenCalledTimes(1);
-          expect(options.tokens.accessToken).toEqual("test-access-token");
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("no error expected.");
-          done();
+        let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.post = (path: string, body: any,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                callback(new Error("bearer-token-error"), undefined, undefined, undefined);
+            };
+            return client;
         });
-  });
 
-  // tslint:disable-next-line:max-line-length
-  it("putConfigObject: bearer token expired, acquire new token from client credentials, error acquiring token.", function(done: () => void): void {
+        let stringClientSpy: jasmine.Spy =
+            spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+                let client: restify.Client = {} as restify.Client;
+                client.put = (path: string, body: any,
+                    callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                    requestedPath = path;
+                    let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
+                    cob.objectIdentifier = "unit-test-cob";
+                    cob.configurationData = body;
+                    callback(undefined, undefined, undefined, JSON.stringify(cob));
+                };
+                return client;
+            });
 
-      // assign an expired jwt.
-      // tslint:disable-next-line:max-line-length
-      options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
-      options.tokens.refreshToken = "";
-      options.credentials = { key: "key", secret: "secret" };
+        ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
+            .then((app: ConfigObjectWrapper) => {
+                fail("error expected.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e).toBeTruthy();
+                expect(e.message).toEqual("bearer-token-error");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                expect(jsonClientSpy).toHaveBeenCalledTimes(1);
+                expect(stringClientSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
 
-      let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.post = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              callback(new Error("bearer-token-error"), undefined, undefined, undefined);
-          };
-          return client;
-      });
+    // tslint:disable-next-line:max-line-length
+    it("putConfigObject: bearer token expired, acquire new token from client credentials, string client.", function(done: () => void): void {
 
-      let stringClientSpy: jasmine.Spy =
-        spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
-          let client: restify.Client = {} as restify.Client;
-          client.put = (path: string, body: any,
-            callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
-              requestedPath = path;
-              let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
-              cob.objectIdentifier = "unit-test-cob";
-              cob.configurationData = body;
-              callback(undefined, undefined, undefined, JSON.stringify(cob));
-          };
-          return client;
-      });
+        // assign an expired jwt.
+        // tslint:disable-next-line:max-line-length
+        options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
+        options.tokens.refreshToken = "";
+        options.credentials = { key: "key", secret: "secret" };
 
-      ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
-        .then((app: ConfigObjectWrapper) => {
-          fail("error expected.");
-          done();
-        })
-        .catch((e: Error) => {
-          expect(e).toBeTruthy();
-          expect(e.message).toEqual("bearer-token-error");
-          expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
-          expect(jsonClientSpy).toHaveBeenCalledTimes(1);
-          expect(stringClientSpy).toHaveBeenCalledTimes(0);
-          done();
+        let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.post = (path: string, body: any,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                let response: any = { "access_token": "test-access-token" };
+                callback(undefined, undefined, undefined, response);
+            };
+            return client;
         });
-  });
+
+        let stringClientSpy: jasmine.Spy =
+            spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+                let client: restify.Client = {} as restify.Client;
+                client.put = (path: string, body: any,
+                    callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                    requestedPath = path;
+                    let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
+                    cob.objectIdentifier = "unit-test-cob";
+                    cob.configurationData = body;
+                    callback(undefined, undefined, undefined, JSON.stringify(cob));
+                };
+                return client;
+            });
+
+        ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
+            .then((cob: ConfigObjectWrapper) => {
+                expect(cob).toBeTruthy();
+                expect(cob.objectIdentifier).toEqual("unit-test-cob");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                expect(jsonClientSpy).toHaveBeenCalledTimes(1);
+                expect(stringClientSpy).toHaveBeenCalledTimes(1);
+                expect(options.tokens.accessToken).toEqual("test-access-token");
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("no error expected.");
+                done();
+            });
+    });
+
+    // tslint:disable-next-line:max-line-length
+    it("putConfigObject: bearer token expired, acquire new token from client credentials, error acquiring token.", function(done: () => void): void {
+
+        // assign an expired jwt.
+        // tslint:disable-next-line:max-line-length
+        options.tokens.accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBMTIzNCIsInVzZXJuYW1lIjoic29tZS11c2VyIiwiaXNzIjoiaHR0cHM6Ly9hcGkuY2xvY28uaW8vdjEvY2xvY28tbm9kZS1jbGllbnQvdGVzdGluZyIsImlhdCI6MTQ4NTQzNzczMywiZXhwIjoxNDg1NDM3NzkzfQ.zoDToEedftG3ao9cNaZYM8UMRTHZJxHfgfpKpOQgABQ";
+        options.tokens.refreshToken = "";
+        options.credentials = { key: "key", secret: "secret" };
+
+        let jsonClientSpy: jasmine.Spy = spyOn(restify, "createJsonClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+            let client: restify.Client = {} as restify.Client;
+            client.post = (path: string, body: any,
+                callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                callback(new Error("bearer-token-error"), undefined, undefined, undefined);
+            };
+            return client;
+        });
+
+        let stringClientSpy: jasmine.Spy =
+            spyOn(restify, "createStringClient").and.callFake((opts: restify.ClientOptions): restify.Client => {
+                let client: restify.Client = {} as restify.Client;
+                client.put = (path: string, body: any,
+                    callback: (err: Error, req: restify.Request, res: restify.Response, obj: any) => void): void => {
+                    requestedPath = path;
+                    let cob: ConfigObjectWrapper = new ConfigObjectWrapper();
+                    cob.objectIdentifier = "unit-test-cob";
+                    cob.configurationData = body;
+                    callback(undefined, undefined, undefined, JSON.stringify(cob));
+                };
+                return client;
+            });
+
+        ApiClient.putConfigObject(options, "objectId", JSON.stringify({ objectType: "test" }))
+            .then((app: ConfigObjectWrapper) => {
+                fail("error expected.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e).toBeTruthy();
+                expect(e.message).toEqual("bearer-token-error");
+                expect(requestedPath).toEqual("/subscription/configuration/application/objectId/test");
+                expect(jsonClientSpy).toHaveBeenCalledTimes(1);
+                expect(stringClientSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
 });

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -19,272 +19,230 @@ import { ApiError } from "./types/api-error";
  */
 export class ApiClient {
 
-  /**
-   * Retrieves the application from the api.
-   * @param  {IOptions}          options The initialization options.
-   * @return {Promise<ClocoApp>}         A promise of the application.
-   */
-  public static async getApplication(options: IOptions): Promise<ClocoApp> {
+    /**
+     * Retrieves the application from the api.
+     * @param  {IOptions}          options The initialization options.
+     * @return {Promise<ClocoApp>}         A promise of the application.
+     */
+    public static async getApplication(options: IOptions): Promise<ClocoApp> {
 
-    Logger.log.debug("ApiClient.getApplication: start");
+        Logger.log.debug("ApiClient.getApplication: start");
 
-    // check the bearer token before making the call
-    Logger.log.debug(`ApiClient.getApplication: Checking bearer token.`);
-    await ApiClient.checkBearerToken(options);
+        // check the bearer token before making the call
+        Logger.log.debug(`ApiClient.getApplication: Checking bearer token.`);
+        await ApiClient.checkBearerToken(options);
 
-    // initialise the restify client.
-    let client: restify.Client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
-    let path: string = `/${options.subscription}/applications/${options.application}`;
-    Logger.log.debug("ApiClient.getApplication: Calling API", {url: options.url}, {path: path});
+        // initialise the restify client.
+        let client: restify.Client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
+        let path: string = `/${options.subscription}/applications/${options.application}`;
+        Logger.log.debug("ApiClient.getApplication: Calling API", { url: options.url }, { path: path });
 
-    return new Promise<ClocoApp>(
-        function(
-            resolve: (value: ClocoApp) => void,
-            reject: (reason: Error) => void): void {
+        return new Promise<ClocoApp>(
+            function(
+                resolve: (value: ClocoApp) => void,
+                reject: (reason: Error) => void): void {
 
-            client.get(
-                path,
-                function(err: Error, req: restify.Request, res: restify.Response, obj: ClocoApp): void {
-                    if (err) {
-                        Logger.log.error(err, "ApiClient.getApplication: Error getting application.");
-                        let apiError: ApiError = new ApiError(err.message, options.subscription, options.application);
-                        reject(apiError);
-                    } else {
-                        Logger.log.debug("ApiClient.getApplication: Application received.", {data: obj});
-                        resolve(obj);
-                    }
-                });
-        });
-  }
-
-  /**
-   * Retrieves the application from the api.
-   * @param  {IOptions}           options           The initialization options.
-   * @param  {string}             objectId          The config object id.
-   * @return {Promise<ConfigObjectWrapper>}         A promise of the config object.
-   */
-  public static async getConfigObject(options: IOptions, objectId: string): Promise<ConfigObjectWrapper> {
-
-    Logger.log.debug("ApiClient.getConfigObject: start");
-
-    // check the bearer token before making the call
-    Logger.log.debug(`ApiClient.getConfigObject: Checking bearer token.`);
-    await ApiClient.checkBearerToken(options);
-
-    // initialise the restify client.
-    let client: restify.Client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
-    let path: string = `/${options.subscription}/configuration/${options.application}/${objectId}/${options.environment}`;
-    Logger.log.debug("ApiClient.getConfigObject: Calling API", {url: options.url}, {path: path});
-
-    return new Promise<ConfigObjectWrapper>(
-        function(
-            resolve: (value: ConfigObjectWrapper) => void,
-            reject: (reason: Error) => void): void {
-
-            client.get(
-                path,
-                function(err: Error, req: restify.Request, res: restify.Response, obj: ConfigObjectWrapper): void {
-                    if (err) {
-                        Logger.log.error(err, `ApiClient.getConfigObject: Error getting configuration object '$objectId'.`);
-                        let apiError: ApiError = new ApiError(
-                          err.message, options.subscription, options.application, objectId, options.environment);
-                        reject(apiError);
-                    } else {
-                        Logger.log.debug("ApiClient.getConfigObject: Configuration object wrapper received.", { data: obj });
-                        resolve(obj);
-                    }
-                });
-        });
-  }
-
-  /**
-   * Writes the config object to the server.
-   * @param  {IOptions}      options  The options.
-   * @param  {string}        objectId The object Id.
-   * @param  {any}           body     The item to write.
-   * @return {Promise<ConfigObjectWrapper>}          A promise of the work completing.
-   */
-  public static async putConfigObject(options: IOptions, objectId: string, body: any): Promise<ConfigObjectWrapper> {
-
-    Logger.log.debug("ApiClient.putConfigObject: start");
-
-    // check the bearer token before making the call
-    Logger.log.debug(`ApiClient.putConfigObject: Checking bearer token.`);
-    await ApiClient.checkBearerToken(options);
-
-    // initialise the restify client.
-    let client: restify.Client;
-    let parseResponse: boolean = false;
-
-    if (typeof body === "string") {
-      Logger.log.debug("ApiClient.putConfigObject: creating string client.");
-      client = restify.createStringClient(ApiClient.getRestifyOptions(options));
-      parseResponse = true;
-    } else {
-      Logger.log.debug("ApiClient.putConfigObject: creating JSON client.");
-      client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
-    }
-
-    let path: string = `/${options.subscription}/configuration/${options.application}/${objectId}/${options.environment}`;
-    Logger.log.debug("ApiClient.putConfigObject: Calling API", {url: options.url}, {path: path});
-
-    return new Promise<ConfigObjectWrapper>(
-        function(
-            resolve: (value: ConfigObjectWrapper) => void,
-            reject: (reason: Error) => void): void {
-
-            client.put(
-                path,
-                body,
-                function(err: Error, req: restify.Request, res: restify.Response, obj: any): void {
-                    if (err) {
-                        Logger.log.error(err, "ApiClient.putConfigObject: Error writing data for configuration object '$objectId'.");
-                        let apiError: ApiError = new ApiError(
-                          err.message, options.subscription, options.application, objectId, options.environment);
-                        reject(apiError);
-                    } else {
-                        if (parseResponse) {
-                          obj = JSON.parse(obj);
+                client.get(
+                    path,
+                    function(err: Error, req: restify.Request, res: restify.Response, obj: ClocoApp): void {
+                        if (err) {
+                            Logger.log.error(err, "ApiClient.getApplication: Error getting application.");
+                            let apiError: ApiError = new ApiError(err.message, options.subscription, options.application);
+                            reject(apiError);
+                        } else {
+                            Logger.log.debug("ApiClient.getApplication: Application received.", { data: obj });
+                            resolve(obj);
                         }
-                        Logger.log.debug("ApiClient.putConfigObject: Success response received.", { data: obj });
-                        resolve(obj);
-                    }
-                });
-        });
-  }
+                    });
+            });
+    }
 
-  /**
-   * Checks the bearer token for expiry and, if expired, refreshes.
-   * @return {Promise<void>} A promise of the work completing.
-   */
-  private static async checkBearerToken(options: IOptions): Promise<void> {
+    /**
+     * Retrieves the application from the api.
+     * @param  {IOptions}           options           The initialization options.
+     * @param  {string}             objectId          The config object id.
+     * @return {Promise<ConfigObjectWrapper>}         A promise of the config object.
+     */
+    public static async getConfigObject(options: IOptions, objectId: string): Promise<ConfigObjectWrapper> {
 
-    Logger.log.debug(`ApiClient.checkBearerToken: start.`);
+        Logger.log.debug("ApiClient.getConfigObject: start");
 
-    try {
-      if (JwtDecoder.bearerTokenExpired(options.tokens.accessToken)) {
+        // check the bearer token before making the call
+        Logger.log.debug(`ApiClient.getConfigObject: Checking bearer token.`);
+        await ApiClient.checkBearerToken(options);
 
-        Logger.log.debug(`ApiClient.checkBearerToken: bearer token has expired and will be refreshed.`);
+        // initialise the restify client.
+        let client: restify.Client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
+        let path: string = `/${options.subscription}/configuration/${options.application}/${objectId}/${options.environment}`;
+        Logger.log.debug("ApiClient.getConfigObject: Calling API", { url: options.url }, { path: path });
 
-        let response: AccessTokenResponse;
-        if (options.credentials) {
-          response = await ApiClient.getAccessTokenFromClientCredentials(options);
+        return new Promise<ConfigObjectWrapper>(
+            function(
+                resolve: (value: ConfigObjectWrapper) => void,
+                reject: (reason: Error) => void): void {
+
+                client.get(
+                    path,
+                    function(err: Error, req: restify.Request, res: restify.Response, obj: ConfigObjectWrapper): void {
+                        if (err) {
+                            Logger.log.error(err, `ApiClient.getConfigObject: Error getting configuration object '$objectId'.`);
+                            let apiError: ApiError = new ApiError(
+                                err.message, options.subscription, options.application, objectId, options.environment);
+                            reject(apiError);
+                        } else {
+                            Logger.log.debug("ApiClient.getConfigObject: Configuration object wrapper received.", { data: obj });
+                            resolve(obj);
+                        }
+                    });
+            });
+    }
+
+    /**
+     * Writes the config object to the server.
+     * @param  {IOptions}      options  The options.
+     * @param  {string}        objectId The object Id.
+     * @param  {any}           body     The item to write.
+     * @return {Promise<ConfigObjectWrapper>}          A promise of the work completing.
+     */
+    public static async putConfigObject(options: IOptions, objectId: string, body: any): Promise<ConfigObjectWrapper> {
+
+        Logger.log.debug("ApiClient.putConfigObject: start");
+
+        // check the bearer token before making the call
+        Logger.log.debug(`ApiClient.putConfigObject: Checking bearer token.`);
+        await ApiClient.checkBearerToken(options);
+
+        // initialise the restify client.
+        let client: restify.Client;
+        let parseResponse: boolean = false;
+
+        if (typeof body === "string") {
+            Logger.log.debug("ApiClient.putConfigObject: creating string client.");
+            client = restify.createStringClient(ApiClient.getRestifyOptions(options));
+            parseResponse = true;
         } else {
-          response = await ApiClient.getAccessTokenFromRefreshToken(options);
+            Logger.log.debug("ApiClient.putConfigObject: creating JSON client.");
+            client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
         }
-        options.tokens.accessToken = response.access_token;
-        Settings.storeBearerToken(response.access_token);
-      }
-    } catch (e) {
-      Logger.log.error(e, "ApiClient.checkBearerToken: error encountered.");
-      throw e;
+
+        let path: string = `/${options.subscription}/configuration/${options.application}/${objectId}/${options.environment}`;
+        Logger.log.debug("ApiClient.putConfigObject: Calling API", { url: options.url }, { path: path });
+
+        return new Promise<ConfigObjectWrapper>(
+            function(
+                resolve: (value: ConfigObjectWrapper) => void,
+                reject: (reason: Error) => void): void {
+
+                client.put(
+                    path,
+                    body,
+                    function(err: Error, req: restify.Request, res: restify.Response, obj: any): void {
+                        if (err) {
+                            Logger.log.error(err, "ApiClient.putConfigObject: Error writing data for configuration object '$objectId'.");
+                            let apiError: ApiError = new ApiError(
+                                err.message, options.subscription, options.application, objectId, options.environment);
+                            reject(apiError);
+                        } else {
+                            if (parseResponse) {
+                                obj = JSON.parse(obj);
+                            }
+                            Logger.log.debug("ApiClient.putConfigObject: Success response received.", { data: obj });
+                            resolve(obj);
+                        }
+                    });
+            });
     }
 
-    Logger.log.debug(`ApiClient.checkBearerToken: complete.`);
-  }
+    /**
+     * Checks the bearer token for expiry and, if expired, refreshes.
+     * @return {Promise<void>} A promise of the work completing.
+     */
+    private static async checkBearerToken(options: IOptions): Promise<void> {
 
-  /**
-   * Refreshes the bearer token.
-   * @param  {IOptions}          options The initialization options.
-   * @return {Promise<AccessTokenResponse>}         A promise of the access token.
-   */
-  private static async getAccessTokenFromRefreshToken(options: IOptions): Promise<AccessTokenResponse> {
+        Logger.log.debug(`ApiClient.checkBearerToken: start.`);
 
-    Logger.log.debug("ApiClient.getAccessTokenFromRefreshToken: start");
+        try {
+            if (!options.tokens.accessToken || JwtDecoder.bearerTokenExpired(options.tokens.accessToken)) {
 
-    // initialise the restify client.
-    let client: restify.Client = restify.createJsonClient(ApiClient.getRestifyOptions(options));
-    let path: string = `/oauth/token`;
-    let body: TokenRequest = new TokenRequest();
-    body.grant_type = "refresh_token";
-    body.refresh_token = options.tokens.refreshToken;
-    Logger.log.debug("ApiClient.getAccessTokenFromRefreshToken: Calling API", {url: options.url}, {path: path});
+                Logger.log.debug(`ApiClient.checkBearerToken: bearer token has expired and will be refreshed.`);
 
-    return new Promise<AccessTokenResponse>(
-        function(
-            resolve: (value: AccessTokenResponse) => void,
-            reject: (reason: Error) => void): void {
+                let response: AccessTokenResponse;
+                response = await ApiClient.getAccessTokenFromClientCredentials(options);
+                options.tokens.accessToken = response.access_token;
+            }
+        } catch (e) {
+            Logger.log.error(e, "ApiClient.checkBearerToken: error encountered.");
+            throw e;
+        }
 
-            client.post(
-                path,
-                body,
-                function(err: Error, req: restify.Request, res: restify.Response, obj: AccessTokenResponse): void {
-                    if (err) {
-                        Logger.log.error(err, "ApiClient.getAccessTokenFromRefreshToken: Error getting access token.");
-                        reject(err);
-                    } else {
-                        Logger.log.debug("ApiClient.getAccessTokenFromRefreshToken: Access token response received.");
-                        resolve(obj);
-                    }
-                });
-        });
-  }
-
-  /**
-   * Refreshes the bearer token.
-   * @param  {IOptions}          options The initialization options.
-   * @return {Promise<AccessTokenResponse>}         A promise of the access token.
-   */
-  private static async getAccessTokenFromClientCredentials(options: IOptions): Promise<AccessTokenResponse> {
-
-    Logger.log.debug("ApiClient.getAccessTokenFromClientCredentials: start");
-
-    // initialise the restify client.
-    let client: restify.Client = restify.createJsonClient(ApiClient.getRestifyOptions(options, "basic"));
-    let path: string = `/oauth/token`;
-    let body: TokenRequest = new TokenRequest();
-    body.grant_type = "client_credentials";
-    Logger.log.debug("ApiClient.getAccessTokenFromClientCredentials: Calling API", {url: options.url}, {path: path});
-
-    return new Promise<AccessTokenResponse>(
-        function(
-            resolve: (value: AccessTokenResponse) => void,
-            reject: (reason: Error) => void): void {
-
-            client.post(
-                path,
-                body,
-                function(err: Error, req: restify.Request, res: restify.Response, obj: AccessTokenResponse): void {
-                    if (err) {
-                        Logger.log.error(err, "ApiClient.getAccessTokenFromClientCredentials: Error getting access token.");
-                        reject(err);
-                    } else {
-                        Logger.log.debug("ApiClient.getAccessTokenFromClientCredentials: Access token response received.");
-                        resolve(obj);
-                    }
-                });
-        });
-  }
-
-  /**
-   * Gets the restify options based on the settings.
-   * @param  {IOptions}              options The options.
-   * @return {restify.ClientOptions}         The restify client options.
-   */
-  private static getRestifyOptions(options: IOptions, credentialType?: string): restify.ClientOptions {
-
-    Logger.log.debug("ApiClient.getRestifyOptions: start");
-
-    let restifyOptions: restify.ClientOptions = {
-        url: options.url,
-        version: "*",
-    };
-
-    let headers: any = {};
-
-    if (credentialType === "basic") {
-      Logger.log.debug("ApiClient.getRestifyOptions: generating auth header with client credentials.");
-      let encoded: string = new Buffer(`${options.credentials.key}:${options.credentials.secret}`).toString("base64");
-      headers.authorization = `Basic ${encoded}`;
-    } else {
-        Logger.log.debug("ApiClient.getRestifyOptions: generating auth header with bearer token.");
-        headers.authorization = `Bearer ${options.tokens.accessToken}`;
+        Logger.log.debug(`ApiClient.checkBearerToken: complete.`);
     }
 
-    restifyOptions.headers = headers;
+    /**
+     * Refreshes the bearer token.
+     * @param  {IOptions}          options The initialization options.
+     * @return {Promise<AccessTokenResponse>}         A promise of the access token.
+     */
+    private static async getAccessTokenFromClientCredentials(options: IOptions): Promise<AccessTokenResponse> {
 
-    Logger.log.debug("ApiClient.getRestifyOptions: end");
+        Logger.log.debug("ApiClient.getAccessTokenFromClientCredentials: start");
 
-    return restifyOptions;
-  }
+        // initialise the restify client.
+        let client: restify.Client = restify.createJsonClient(ApiClient.getRestifyOptions(options, "basic"));
+        let path: string = `/oauth/token`;
+        let body: TokenRequest = new TokenRequest();
+        body.grant_type = "client_credentials";
+        Logger.log.debug("ApiClient.getAccessTokenFromClientCredentials: Calling API", { url: options.url }, { path: path });
+
+        return new Promise<AccessTokenResponse>(
+            function(
+                resolve: (value: AccessTokenResponse) => void,
+                reject: (reason: Error) => void): void {
+
+                client.post(
+                    path,
+                    body,
+                    function(err: Error, req: restify.Request, res: restify.Response, obj: AccessTokenResponse): void {
+                        if (err) {
+                            Logger.log.error(err, "ApiClient.getAccessTokenFromClientCredentials: Error getting access token.");
+                            reject(err);
+                        } else {
+                            Logger.log.debug("ApiClient.getAccessTokenFromClientCredentials: Access token response received.");
+                            resolve(obj);
+                        }
+                    });
+            });
+    }
+
+    /**
+     * Gets the restify options based on the settings.
+     * @param  {IOptions}              options The options.
+     * @return {restify.ClientOptions}         The restify client options.
+     */
+    private static getRestifyOptions(options: IOptions, credentialType?: string): restify.ClientOptions {
+
+        Logger.log.debug("ApiClient.getRestifyOptions: start");
+
+        let restifyOptions: restify.ClientOptions = {
+            url: options.url,
+            version: "*",
+        };
+
+        let headers: any = {};
+
+        if (credentialType === "basic") {
+            Logger.log.debug("ApiClient.getRestifyOptions: generating auth header with client credentials.");
+            let encoded: string = new Buffer(`${options.credentials.key}:${options.credentials.secret}`).toString("base64");
+            headers.authorization = `Basic ${encoded}`;
+        } else {
+            Logger.log.debug("ApiClient.getRestifyOptions: generating auth header with bearer token.");
+            headers.authorization = `Bearer ${options.tokens.accessToken}`;
+        }
+
+        restifyOptions.headers = headers;
+
+        Logger.log.debug("ApiClient.getRestifyOptions: end");
+
+        return restifyOptions;
+    }
 }

--- a/src/cache/cache.spec.ts
+++ b/src/cache/cache.spec.ts
@@ -16,7 +16,7 @@ describe("Cache unit tests", function(): void {
     });
 
     afterAll(function(): void {
-      Cache.current = undefined;
+        Cache.current = undefined;
     });
 
     it("init: cache singleton should be created successfully.", function(): void {
@@ -115,7 +115,7 @@ describe("Cache unit tests", function(): void {
         item.value = "value";
 
         let cache: Cache = new Cache();
-        cache.items = [{key: "test", value: "old"} as CacheItem];
+        cache.items = [{ key: "test", value: "old" } as CacheItem];
         cache.add(item);
 
         expect(cache.items.length).toEqual(1);
@@ -186,28 +186,28 @@ describe("Cache unit tests", function(): void {
 
     it("addItem: item with lower revision exists, item is added.", function(): void {
 
-      let cache: Cache = new Cache();
-      let added: CacheItem = cache.addItem("test", "value", 2);
+        let cache: Cache = new Cache();
+        let added: CacheItem = cache.addItem("test", "value", 2);
 
-      expect(cache.items.length).toEqual(1);
-      expect(cache.items[0].value).toEqual("value");
-      expect(cache.items[0].expires).toBeFalsy();
-      expect(cache.items[0].revision).toEqual(2);
-      expect(added).toBeTruthy();
+        expect(cache.items.length).toEqual(1);
+        expect(cache.items[0].value).toEqual("value");
+        expect(cache.items[0].expires).toBeFalsy();
+        expect(cache.items[0].revision).toEqual(2);
+        expect(added).toBeTruthy();
 
-      let updated: CacheItem = cache.addItem("test", "new-value", 3);
+        let updated: CacheItem = cache.addItem("test", "new-value", 3);
 
-      expect(cache.items.length).toEqual(1);
-      expect(cache.items[0].value).toEqual("new-value");
-      expect(cache.items[0].expires).toBeFalsy();
-      expect(cache.items[0].revision).toEqual(3);
-      expect(updated).toBeTruthy();
+        expect(cache.items.length).toEqual(1);
+        expect(cache.items[0].value).toEqual("new-value");
+        expect(cache.items[0].expires).toBeFalsy();
+        expect(cache.items[0].revision).toEqual(3);
+        expect(updated).toBeTruthy();
     });
 
     it("remove: cache item should be removed successfully.", function(): void {
 
         let cache: Cache = new Cache();
-        cache.items = [{key: "test", value: "old"} as CacheItem];
+        cache.items = [{ key: "test", value: "old" } as CacheItem];
         cache.remove("test");
 
         expect(cache.items.length).toEqual(0);
@@ -216,7 +216,7 @@ describe("Cache unit tests", function(): void {
     it("remove: cache item not existing should remove without error.", function(): void {
 
         let cache: Cache = new Cache();
-        cache.items = [{key: "test", value: "old"} as CacheItem];
+        cache.items = [{ key: "test", value: "old" } as CacheItem];
         cache.remove("foo");
 
         expect(cache.items.length).toEqual(1);
@@ -233,133 +233,130 @@ describe("Cache unit tests", function(): void {
 
     it("isExpired: cache item should not be expired if no expires set", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      expect(item.isExpired()).toBeFalsy();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        expect(item.isExpired()).toBeFalsy();
 
     });
 
     it("isExpired: cache item should not be expired if future expires set", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
-      item.expires.setTime(item.expires.getTime() + 5);
-      expect(item.isExpired()).toBeFalsy();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
+        item.expires.setTime(item.expires.getTime() + 5);
+        expect(item.isExpired()).toBeFalsy();
     });
 
     it("isExpired: cache item should be expired if past expires set", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
-      item.expires.setTime(item.expires.getTime() - 5);
-      expect(item.isExpired()).toBeTruthy();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
+        item.expires.setTime(item.expires.getTime() - 5);
+        expect(item.isExpired()).toBeTruthy();
     });
 
     it("isExpired: cache item should be expired immediate expires set", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
-      expect(item.isExpired()).toBeFalsy();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
+        expect(item.isExpired()).toBeFalsy();
     });
 
     it("exists: existing cache item should return true", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
 
-      let cache: Cache = new Cache();
-      cache.items = [item];
+        let cache: Cache = new Cache();
+        cache.items = [item];
 
-      expect(cache.exists("test")).toBeTruthy();
+        expect(cache.exists("test")).toBeTruthy();
     });
 
     it("exists: non-existing cache item should return false", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
 
-      let cache: Cache = new Cache();
-      cache.items = [item];
+        let cache: Cache = new Cache();
+        cache.items = [item];
 
-      expect(cache.exists("unknown")).toBeFalsy();
+        expect(cache.exists("unknown")).toBeFalsy();
     });
 
     it("exists: empty cache should return false", function(): void {
 
-      let cache: Cache = new Cache();
-      cache.items = [];
+        let cache: Cache = new Cache();
+        cache.items = [];
 
-      expect(cache.exists("unknown")).toBeFalsy();
+        expect(cache.exists("unknown")).toBeFalsy();
     });
 
     it("exists: undefined cache should return false", function(): void {
 
-      let cache: Cache = new Cache();
-      cache.items = undefined;
+        let cache: Cache = new Cache();
+        cache.items = undefined;
 
-      let spy: jasmine.Spy = spyOn(Logger.log, "warn").and.callThrough();
+        let spy: jasmine.Spy = spyOn(Logger.log, "warn").and.callThrough();
 
-      expect(cache.exists("unknown")).toBeFalsy();
-      expect(spy).toHaveBeenCalled();
+        expect(cache.exists("unknown")).toBeFalsy();
+        expect(spy).toHaveBeenCalled();
     });
 
     it("get: existing cache item should be returned", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
 
-      let cache: Cache = new Cache();
-      cache.items = [item];
+        let cache: Cache = new Cache();
+        cache.items = [item];
 
-      let value: any = cache.get("test");
+        let value: any = cache.get("test");
 
-      expect(value).toBeTruthy();
-      expect(value.value).toEqual("value");
+        expect(value).toBeTruthy();
+        expect(value.value).toEqual("value");
     });
 
     it("get: non-existing cache item should return undefined", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
 
-      let cache: Cache = new Cache();
-      cache.items = [item];
+        let cache: Cache = new Cache();
+        cache.items = [item];
 
-      expect(cache.get("unknown")).toBeFalsy();
+        expect(cache.get("unknown")).toBeFalsy();
     });
 
-    it("get: non-existing cache item should return undefined", function(): void {
+    it("get: existing cache item should return a value", function(): void {
 
-      let item: CacheItem = new CacheItem();
-      item.key = "test";
-      item.value = "value";
-      item.expires = new Date();
-      item.expires.setDate(item.expires.getDate() - 1);
+        let item: CacheItem = new CacheItem();
+        item.key = "test";
+        item.value = "value";
+        item.expires = new Date();
+        item.expires.setDate(item.expires.getDate() - 1);
 
-      let spy: jasmine.Spy = spyOn(Logger.log, "info").and.callThrough();
+        let cache: Cache = new Cache();
+        cache.items = [item];
 
-      let cache: Cache = new Cache();
-      cache.items = [item];
+        let value: any = cache.get("test");
 
-      let value: any = cache.get("test");
-
-      expect(value).toBeTruthy();
-      expect(value.value).toEqual("value");
-      expect(spy).toHaveBeenCalled();
+        expect(value).toBeTruthy();
+        expect(value.value).toEqual("value");
     });
 });

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -9,156 +9,156 @@ import { CacheItem } from "./cache-item";
  *   Represents a cache for configuration objects.
  */
 export class Cache {
-  public static current: Cache;
-  public items: CacheItem[] = [];
+    public static current: Cache;
+    public items: CacheItem[] = [];
 
-  /**
-   * Static constructor for the cache singleton.
-   */
-  public static init(): void {
-    Cache.current = new Cache();
-  }
-
-  /**
-   * Adds an item to the cache.
-   * @param {CacheItem} item A cache item.
-   */
-  public add(item: CacheItem): void {
-
-    Logger.log.debug("Cache.add: start");
-
-    // set the expiry.
-    Logger.log.debug(`Cache.add: Attempting to set the expiry from the TTL.  TTL: '${item.ttl}'`);
-    if (item.ttl >= 0) {
-      item.expires = new Date();
-      item.expires.setTime(item.expires.getTime() + item.ttl * 1000);
-      Logger.log.debug(`Cache.add: Item expiry has been set: '${item.expires}'`);
+    /**
+     * Static constructor for the cache singleton.
+     */
+    public static init(): void {
+        Cache.current = new Cache();
     }
 
-    if (!this.items) {
-      Logger.log.debug("Cache.add: Items array does not exist.  Creating...");
-      this.items = [item];
-      return;
-    } else {
-      for (let i: number = 0; i < this.items.length; i++) {
-        if (this.items[i].key === item.key) {
-          Logger.log.debug(`Cache.add: Item '${item.key}' located in items array.  Updating....`);
-          this.items[i] = item;
-          return;
+    /**
+     * Adds an item to the cache.
+     * @param {CacheItem} item A cache item.
+     */
+    public add(item: CacheItem): void {
+
+        Logger.log.debug("Cache.add: start");
+
+        // set the expiry.
+        Logger.log.debug(`Cache.add: Attempting to set the expiry from the TTL.  TTL: '${item.ttl}'`);
+        if (item.ttl >= 0) {
+            item.expires = new Date();
+            item.expires.setTime(item.expires.getTime() + item.ttl * 1000);
+            Logger.log.debug(`Cache.add: Item expiry has been set: '${item.expires}'`);
         }
-      }
 
-      Logger.log.debug("Cache.add: Item not located in items array.  Adding....");
-      this.items.push(item);
-      Logger.log.debug(`Cache.add: Cache contains '${this.items.length}' items.`);
-    }
-  }
+        if (!this.items) {
+            Logger.log.debug("Cache.add: Items array does not exist.  Creating...");
+            this.items = [item];
+            return;
+        } else {
+            for (let i: number = 0; i < this.items.length; i++) {
+                if (this.items[i].key === item.key) {
+                    Logger.log.debug(`Cache.add: Item '${item.key}' located in items array.  Updating....`);
+                    this.items[i] = item;
+                    return;
+                }
+            }
 
-  /**
-   * Adds an item by creating the cache item then adding to the cache.
-   * @param {string} key   The key.
-   * @param {any}    value The item to add.
-   * @param {number} revision   The item's revision number.
-   * @param {number} ttl   The TTL of the item in cache.
-   */
-  public addItem(key: string, value: any, revision: number, ttl?: number): CacheItem {
-
-    Logger.log.debug(`Cache.addItem: start. key: '${key}', revision: '${revision}'`);
-
-    let existing: CacheItem = this.get(key);
-
-    if (!existing || existing.revision < revision) {
-
-      Logger.log.debug(`Cache.addItem: new revision '${revision}' detected, adding to cache.`);
-
-      let cacheItem: CacheItem = new CacheItem();
-      cacheItem.key = key;
-      cacheItem.value = value;
-      cacheItem.revision = revision;
-      cacheItem.ttl = ttl;
-
-      this.add(cacheItem);
-
-      return cacheItem;
-    } else {
-      this.add(existing);
-      Logger.log.debug(`Cache.addItem: no change from existing revision '${revision}', no cache update.`);
-      return undefined;
-    }
-  }
-
-  /**
-   * Gets an item from the cache.
-   * @param  {string} key The item key.
-   * @return {CacheItem}  The cache item.
-   */
-  public get(key: string): CacheItem {
-
-    Logger.log.debug("Cache.get: start");
-
-    if (this.exists(key)) {
-      for (let i: number = 0; i < this.items.length; i++) {
-        if (this.items[i].key === key) {
-          Logger.log.debug(`Cache.get: Item '${key}' located in items array.  Returning....`);
-          if (this.items[i].isExpired()) {
-            Logger.log.info(`Cache.get: Item '${key}' has expired.`);
-          }
-          return this.items[i];
+            Logger.log.debug("Cache.add: Item not located in items array.  Adding....");
+            this.items.push(item);
+            Logger.log.debug(`Cache.add: Cache contains '${this.items.length}' items.`);
         }
-      }
-      return undefined;
-    } else {
-      Logger.log.debug("Cache.get: Item not located in items array.");
-      return undefined;
     }
-  }
 
-  /**
-   * Checks for the existence of the item in the cache.
-   * @param  {string}  key The key of the item.
-   * @return {boolean}     A value indicating whether the item exists in the cache.
-   */
-  public exists(key: string): boolean {
+    /**
+     * Adds an item by creating the cache item then adding to the cache.
+     * @param {string} key   The key.
+     * @param {any}    value The item to add.
+     * @param {number} revision   The item's revision number.
+     * @param {number} ttl   The TTL of the item in cache.
+     */
+    public addItem(key: string, value: any, revision: number, ttl?: number): CacheItem {
 
-    Logger.log.debug("Cache.exists: start");
+        Logger.log.debug(`Cache.addItem: start. key: '${key}', revision: '${revision}'`);
 
-    if (!this.items) {
-      Logger.log.warn("Cache.exists: Items array does not exist.");
-      return false;
-    } else {
-      for (let i: number = 0; i < this.items.length; i++) {
-        if (this.items[i].key === key) {
-          Logger.log.debug(`Cache.exists: Item '${key}' located in items array.`);
-          return true;
+        let existing: CacheItem = this.get(key);
+
+        if (!existing || existing.revision < revision) {
+
+            Logger.log.info(`Cache.addItem: new revision '${revision}' detected, adding to cache.`);
+
+            let cacheItem: CacheItem = new CacheItem();
+            cacheItem.key = key;
+            cacheItem.value = value;
+            cacheItem.revision = revision;
+            cacheItem.ttl = ttl;
+
+            this.add(cacheItem);
+
+            return cacheItem;
+        } else {
+            this.add(existing);
+            Logger.log.debug(`Cache.addItem: no change from existing revision '${revision}', no cache update.`);
+            return undefined;
         }
-      }
-
-      Logger.log.debug("Cache.exists: Item not located in items array.");
-      return false;
     }
-  }
 
-  /**
-   * Removes the cache item from the array.
-   * @param {string} key The key of the cache item to remove.
-   */
-  public remove(key: string): void {
+    /**
+     * Gets an item from the cache.
+     * @param  {string} key The item key.
+     * @return {CacheItem}  The cache item.
+     */
+    public get(key: string): CacheItem {
 
-    Logger.log.debug("Cache.remove: start");
+        Logger.log.debug("Cache.get: start");
 
-    if (!this.items) {
-      Logger.log.debug("Cache.remove: Items array does not exist.");
-      return;
-    } else {
-      for (let i: number = 0; i < this.items.length; i++) {
-        if (this.items[i].key === key) {
-          Logger.log.debug("Cache.remove: Item located in items array.  Removing....");
-          this.items.splice(i, 1);
-          return;
+        if (this.exists(key)) {
+            for (let i: number = 0; i < this.items.length; i++) {
+                if (this.items[i].key === key) {
+                    Logger.log.debug(`Cache.get: Item '${key}' located in items array.  Returning....`);
+                    if (this.items[i].isExpired()) {
+                        Logger.log.debug(`Cache.get: Item '${key}' has expired.`);
+                    }
+                    return this.items[i];
+                }
+            }
+            return undefined;
+        } else {
+            Logger.log.debug("Cache.get: Item not located in items array.");
+            return undefined;
         }
-      }
-
-      Logger.log.debug("Cache.remove: Item not located in items array.");
     }
-  }
+
+    /**
+     * Checks for the existence of the item in the cache.
+     * @param  {string}  key The key of the item.
+     * @return {boolean}     A value indicating whether the item exists in the cache.
+     */
+    public exists(key: string): boolean {
+
+        Logger.log.debug("Cache.exists: start");
+
+        if (!this.items) {
+            Logger.log.warn("Cache.exists: Items array does not exist.");
+            return false;
+        } else {
+            for (let i: number = 0; i < this.items.length; i++) {
+                if (this.items[i].key === key) {
+                    Logger.log.debug(`Cache.exists: Item '${key}' located in items array.`);
+                    return true;
+                }
+            }
+
+            Logger.log.debug("Cache.exists: Item not located in items array.");
+            return false;
+        }
+    }
+
+    /**
+     * Removes the cache item from the array.
+     * @param {string} key The key of the cache item to remove.
+     */
+    public remove(key: string): void {
+
+        Logger.log.debug("Cache.remove: start");
+
+        if (!this.items) {
+            Logger.log.debug("Cache.remove: Items array does not exist.");
+            return;
+        } else {
+            for (let i: number = 0; i < this.items.length; i++) {
+                if (this.items[i].key === key) {
+                    Logger.log.debug("Cache.remove: Item located in items array.  Removing....");
+                    this.items.splice(i, 1);
+                    return;
+                }
+            }
+
+            Logger.log.debug("Cache.remove: Item not located in items array.");
+        }
+    }
 }

--- a/src/cloco-client.spec.ts
+++ b/src/cloco-client.spec.ts
@@ -20,1010 +20,1010 @@ import { Settings } from "./settings";
 
 describe("ClocoClient unit tests", function(): void {
 
-  let options: IOptions;
-  let configSpy: jasmine.Spy;
-  let app: ClocoApp;
-  let cob: ConfigObjectWrapper;
-  let aes: AesEncryptor;
-  let getCobHitIndex: number;
+    let options: IOptions;
+    let configSpy: jasmine.Spy;
+    let app: ClocoApp;
+    let cob: ConfigObjectWrapper;
+    let aes: AesEncryptor;
+    let getCobHitIndex: number;
 
-  beforeAll(function(done: () => void): void {
-    Logger.init({});
-    configSpy = spyOn(Settings, "readFileContent").and.callFake((path: string) => {
-      return "file-content";
+    beforeAll(function(done: () => void): void {
+        Logger.init({});
+        configSpy = spyOn(Settings, "readFileContent").and.callFake((path: string) => {
+            return "file-content";
+        });
+        done();
     });
-    done();
-  });
 
-  beforeEach(function(done: () => void): void {
-
-    Cache.init();
-
-    getCobHitIndex = 0;
-
-    options = {};
-    options.tokens = { accessToken: "", refreshToken: "refresh-token" };
-    options.url = "https://test.api.cloco.io";
-    options.subscription = "subscription";
-    options.application = "application";
-    options.environment = "test";
-    options.cacheCheckInterval = -1;
-
-    app = {
-      applicationIdentifier: "test-app",
-      configObjects: [
-        {
-          description: "a sample configuration object",
-          encrypted: false,
-          format: "JSON",
-          objectIdentifier: "test-cob",
-          objectName: "Test Configuration Object",
-        },
-      ],
-      coreDetails: {
-        applicationName: "Test Application",
-        description: "A test application for unit testing.",
-        isDefault: false,
-      },
-      created: new Date(),
-      createdBy: "unit-test",
-      displayIndex: 1,
-      environments: [
-        {
-          description: "the test environment",
-          environmentIdentifier: "test",
-          environmentName: "Test",
-          isDefault: true,
-        },
-      ],
-      lastUpdated: new Date(),
-      lastUpdatedBy: "unit-test",
-      revisionNumber: 2,
-      subscriptionIdentifier: "test-subscription",
-    };
-
-    cob = {
-      applicationIdentifier: "test-app",
-      configurationData: {
-        foo: "bar",
-      },
-      contentLength: 100,
-      created: new Date(),
-      createdBy: "unit-test",
-      environmentIdentifier: "test",
-      lastUpdated: new Date(),
-      lastUpdatedBy: "unit-test",
-      objectIdentifier: "test-cob",
-      revisionNumber: 2,
-      subscriptionIdentifier: "test-subscription",
-      versionNote: "created by unit test",
-    };
-
-    aes = new AesEncryptor("cloco-unit-test-encryption-key");
-
-    let generator: JwtGenerator = new JwtGenerator();
-    generator.generateJwt("A1234", "some-user")
-      .then((jwt: string) => {
-        options.tokens.accessToken = jwt;
-        done();
-      });
-  });
-
-  it("constructor: construct the client from the options.", function(): void {
-      let client: ClocoClient = new ClocoClient(options);
-      expect(client.onCacheExpired).toBeTruthy();
-  });
-
-  it("constructor: error raised in setting defaults.", function(): void {
-
-      options.environment = "";
-
-      let envSpy: jasmine.Spy = spyOn(Settings, "getDefaultEnvironment").and.callFake((): void => {
-        throw new Error("unit-test-error");
-      });
-
-      let client: ClocoClient;
-
-      try {
-        client = new ClocoClient(options);
-        fail("expect error to have been thrown.");
-      } catch (e) {
-        expect(e.message).toEqual("unit-test-error");
-        expect(envSpy).toHaveBeenCalledTimes(1);
-      }
-  });
-
-  it("init: successful happy path initialization, loads application and config object.", function(done: () => void): void {
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(1);
-        expect(Cache.current.items[0].value).toEqual(cob.configurationData);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(1);
-        done();
-      })
-      .catch((e: Error) => {
-        console.log(e);
-        fail("error not expected");
-        done();
-      });
-  });
-
-  it("init: successful initialization, loads application and config object, cache on disk.", function(done: () => void): void {
-
-      options.useDiskCaching = true;
-      let filenames: string[] = [];
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
-        .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
-          filenames.push(f);
-          callback(undefined);
-      });
-
-      client.init()
-      .then(() => {
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(1);
-        expect(Cache.current.items[0].value).toEqual(cob.configurationData);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(1);
-        expect(filenames.length).toEqual(2);
-        expect(filenames[0]).toEqual(`${process.env.HOME}/.cloco/cache/application_application`);
-        done();
-      })
-      .catch((e: Error) => {
-        console.log(e);
-        fail("error not expected");
-        done();
-      });
-  });
-
-  it("init: successful initialization, loads application and config object, fail to cache on disk.", function(done: () => void): void {
-
-      options.useDiskCaching = true;
-      let filenames: string[] = [];
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
-        .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
-          filenames.push(f);
-          callback(new Error("disk-error"));
-      });
-      let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(false);
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("disk-error");
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        expect(writeFileSpy).toHaveBeenCalledTimes(1);
-        expect(fileExistsSpy).toHaveBeenCalledTimes(0);
-        expect(filenames.length).toEqual(1);
-        expect(filenames[0]).toEqual(`${process.env.HOME}/.cloco/cache/application_application`);
-        done();
-      });
-  });
-
-  it("init: failure to load application, error.", function(done: () => void): void {
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
-        .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("app-error");
-        expect(client.app).toEqual(undefined);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        done();
-      });
-  });
-
-  it("init: failure to load application, load from disk, success.", function(done: () => void): void {
-
-      options.useDiskCaching = true;
-      let filenames: string[] = [];
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
-        .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
-      let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
-        .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
-          callback(undefined, JSON.stringify(app));
-      });
-      let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
-        .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
-          filenames.push(f);
-          callback(undefined);
-      });
-
-      client.init()
-      .then(() => {
-        expect(client.app.applicationIdentifier).toEqual(app.applicationIdentifier);
-        expect(Cache.current.items.length).toEqual(1);
-        expect(Cache.current.items[0].value).toEqual(cob.configurationData);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(1);
-        expect(fileExistsSpy).toHaveBeenCalledTimes(1);
-        expect(readFileSpy).toHaveBeenCalledTimes(1);
-        expect(filenames.length).toEqual(1);
-        done();
-      })
-      .catch((e: Error) => {
-        console.log(e);
-        fail("error not expected");
-        done();
-      });
-  });
-
-  it("init: failure to load application, load from disk, file not found, fail.", function(done: () => void): void {
-
-      options.useDiskCaching = true;
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
-        .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(false);
-      let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
-        .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
-          callback(undefined, JSON.stringify(app));
-      });
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("app-error");
-        expect(client.app).toEqual(undefined);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        expect(fileExistsSpy).toHaveBeenCalledTimes(1);
-        expect(readFileSpy).toHaveBeenCalledTimes(0);
-        done();
-      });
-  });
-
-  it("init: failure to load application, load from disk, invalid JSON, fail.", function(done: () => void): void {
-
-      options.useDiskCaching = true;
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
-        .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
-      let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
-        .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
-          callback(undefined, "{invalid-JSON]");
-      });
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("Unexpected token i in JSON at position 1");
-        expect(client.app).toEqual(undefined);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        expect(fileExistsSpy).toHaveBeenCalledTimes(1);
-        expect(readFileSpy).toHaveBeenCalledTimes(1);
-        done();
-      });
-  });
-
-  it("init: failure to load application, load from disk, disk read fails, fail.", function(done: () => void): void {
-
-      options.useDiskCaching = true;
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
-        .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
-      let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
-        .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
-          callback(new Error("cat-error"), undefined);
-      });
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("cat-error");
-        expect(client.app).toEqual(undefined);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        expect(fileExistsSpy).toHaveBeenCalledTimes(1);
-        expect(readFileSpy).toHaveBeenCalledTimes(1);
-        done();
-      });
-  });
-
-  it("init: failure to load configuration, error.", function(done: () => void): void {
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject")
-        .and.returnValue(ApiClientMock.getConfigObject(cob, new Error("cob-error")));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("cob-error");
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(1);
-        done();
-      });
-  });
-
-  it("init: environment not found in application, error.", function(done: () => void): void {
-
-      options.environment = "unknown";
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("The environment 'unknown' does not exist in application.");
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        done();
-      });
-  });
-
-  it("init: no application returned by api, error.", function(done: () => void): void {
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(undefined));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("The environment 'test' does not exist in application.");
-        expect(client.app).toEqual(undefined);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        done();
-      });
-  });
-
-  it("init: no environments in application returned by api, error.", function(done: () => void): void {
-
-      app.environments = undefined;
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("The environment 'test' does not exist in application.");
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        done();
-      });
-  });
-
-  it("init: empty environments array in application returned by api, error.", function(done: () => void): void {
-
-      app.environments = [];
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("The environment 'test' does not exist in application.");
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        done();
-      });
-  });
-
-  it("init: empty environments option, error.", function(done: () => void): void {
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      options.environment = "";
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("The environment '' does not exist in application.");
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(0);
-        done();
-      });
-  });
-
-  it("init: failure to load config, use disk cache, success.", function(done: () => void): void {
-
-      options.useDiskCaching = true;
-      let filenames: string[] = [];
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject")
-        .and.returnValue(ApiClientMock.getConfigObject(cob, new Error("cob-error")));
-      let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
-      let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
-        .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
-          callback(undefined, JSON.stringify(cob));
-      });
-      let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
-        .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
-          filenames.push(f);
-          callback(undefined);
-      });
-
-      client.init()
-      .then(() => {
-        expect(client.app.applicationIdentifier).toEqual(app.applicationIdentifier);
-        expect(Cache.current.items.length).toEqual(1);
-        expect(Cache.current.items[0].value).toEqual(cob.configurationData);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(1);
-        expect(fileExistsSpy).toHaveBeenCalledTimes(1);
-        expect(readFileSpy).toHaveBeenCalledTimes(1);
-        expect(writeFileSpy).toHaveBeenCalledTimes(1);
-        expect(filenames.length).toEqual(1);
-        done();
-      })
-      .catch((e: Error) => {
-        console.log(e);
-        fail("error not expected");
-        done();
-      });
-  });
-
-  it("init: failure to decrypt config, fail.", function(done: () => void): void {
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-      spyOn(client, "decryptAndDecode").and.callFake((): void => {
-        throw new Error("decrypt-error");
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-      .then(() => {
-        fail("expect error to have been thrown.");
-        done();
-      })
-      .catch((e: Error) => {
-        expect(e.message).toEqual("decrypt-error");
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(1);
-        done();
-      });
-  });
-
-  it("init: load config, no item added to cache, success.", function(done: () => void): void {
-
-      let client: ClocoClient = new ClocoClient(options);
-      spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
-        return;
-      });
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let addItemSpy: jasmine.Spy = spyOn(Cache.current, "addItem").and.returnValue(undefined);
-
-      client.init()
-      .then(() => {
-        expect(client.app).toEqual(app);
-        expect(Cache.current.items.length).toEqual(0);
-        expect(getAppSpy).toHaveBeenCalledTimes(1);
-        expect(getCobSpy).toHaveBeenCalledTimes(1);
-        expect(addItemSpy).toHaveBeenCalledTimes(1);
-        done();
-      })
-      .catch((e: Error) => {
-        fail("expect error to have been thrown.");
-        done();
-      });
-  });
-
-  it("checkCacheTimeouts: cache item expired, reloads the config.", function(done: () => void): void {
-
-      let client: ClocoClient = new ClocoClient(options);
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
-
-          // the client is initialized now, so set an expiry on the cache item
-          let item: CacheItem = Cache.current.items[0];
-          item.expires = new Date();
-          item.expires.setDate(item.expires.getDate() - 1); // set to be expired
-
-          client.checkCacheTimeouts();
-          expect(getCobSpy).toHaveBeenCalledTimes(2);
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
-        });
-  });
-
-  it("checkCacheTimeouts: cache item not expired, reload config, no update.", function(done: () => void): void {
-
-      let client: ClocoClient = new ClocoClient(options);
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let dispatchSpy: jasmine.Spy = spyOn(client.onConfigurationLoaded, "dispatch").and.callThrough();
-
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
-
-          // the client is initialized now, so set an expiry on the cache item
-          let item: CacheItem = Cache.current.items[0];
-          item.expires = new Date();
-          item.expires.setDate(item.expires.getDate() - 1); // set to be expired
-
-          spyOn(Cache.current, "addItem").and.returnValue(undefined); // no item added to cache
-
-          client.checkCacheTimeouts();
-          expect(getCobSpy).toHaveBeenCalledTimes(2); // shows that the config loaded twice.
-          expect(dispatchSpy).toHaveBeenCalledTimes(1); // shows that the config published once.
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
-        });
-  });
-
-  it("checkCacheTimeouts: cache item not expired, no reload of config.", function(done: () => void): void {
-
-      let client: ClocoClient = new ClocoClient(options);
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
-
-          // the client is initialized now, so set an expiry on the cache item
-          let item: CacheItem = Cache.current.items[0];
-          item.expires = new Date();
-          item.expires.setDate(item.expires.getDate() + 1); // set to be expired
-
-          client.checkCacheTimeouts();
-          expect(getCobSpy).toHaveBeenCalledTimes(1); // shows that the config is not reloaded.
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
-        });
-  });
-
-  /*it("checkCacheTimeouts: cache item expired, reloads config, error.", function(done: () => void): void {
-
-      Logger.log = bunyan.createLogger({
-            level: "debug",
-            name: "cloco-node-client",
+    beforeEach(function(done: () => void): void {
+
+        Cache.init();
+
+        getCobHitIndex = 0;
+
+        options = {};
+        options.tokens = { accessToken: "", refreshToken: "refresh-token" };
+        options.url = "https://test.api.cloco.io";
+        options.subscription = "subscription";
+        options.application = "application";
+        options.environment = "test";
+        options.cacheCheckInterval = -1;
+
+        app = {
+            applicationIdentifier: "test-app",
+            configObjects: [
+                {
+                    description: "a sample configuration object",
+                    encrypted: false,
+                    format: "JSON",
+                    objectIdentifier: "test-cob",
+                    objectName: "Test Configuration Object",
+                },
+            ],
+            coreDetails: {
+                applicationName: "Test Application",
+                description: "A test application for unit testing.",
+                isFavorite: false,
+            },
+            created: new Date(),
+            createdBy: "unit-test",
+            displayIndex: 1,
+            environments: [
+                {
+                    description: "the test environment",
+                    environmentIdentifier: "test",
+                    environmentName: "Test",
+                    isDefault: true,
+                },
+            ],
+            lastUpdated: new Date(),
+            lastUpdatedBy: "unit-test",
+            revisionNumber: 2,
+            subscriptionIdentifier: "test-subscription",
+        };
+
+        cob = {
+            applicationIdentifier: "test-app",
+            configurationData: {
+                foo: "bar",
+            },
+            contentLength: 100,
+            created: new Date(),
+            createdBy: "unit-test",
+            environmentIdentifier: "test",
+            lastUpdated: new Date(),
+            lastUpdatedBy: "unit-test",
+            objectIdentifier: "test-cob",
+            revisionNumber: 2,
+            subscriptionIdentifier: "test-subscription",
+            versionNote: "created by unit test",
+        };
+
+        aes = new AesEncryptor("cloco-unit-test-encryption-key");
+
+        let generator: JwtGenerator = new JwtGenerator();
+        generator.generateJwt("A1234", "some-user")
+            .then((jwt: string) => {
+                options.tokens.accessToken = jwt;
+                done();
+            });
+    });
+
+    it("constructor: construct the client from the options.", function(): void {
+        let client: ClocoClient = new ClocoClient(options);
+        expect(client.onCacheExpired).toBeTruthy();
+    });
+
+    it("constructor: error raised in setting defaults.", function(): void {
+
+        options.environment = "";
+
+        let envSpy: jasmine.Spy = spyOn(Settings, "getDefaultEnvironment").and.callFake((): void => {
+            throw new Error("unit-test-error");
         });
 
-      let client: ClocoClient = new ClocoClient(options);
-      let emittedError: Error;
-      client.onError.subscribe((sender: ClocoClient, e: Error): void => {
-          console.log(e);
-          emittedError = e;
-      });
+        let client: ClocoClient;
 
-      let func: any = (sender: ClocoClient, value: CacheItem): void => {
-        console.log(value);
-        console.log(`Hit index: ${getCobHitIndex}`);
-        if (getCobHitIndex === 2) {
-          throw new Error("subsequent-error");
+        try {
+            client = new ClocoClient(options);
+            fail("expect error to have been thrown.");
+        } catch (e) {
+            expect(e.message).toEqual("unit-test-error");
+            expect(envSpy).toHaveBeenCalledTimes(1);
         }
-      };
+    });
 
-      // set up a subscription to throw an error next time config is loaded
-      client.onConfigurationLoaded.subscribe(func);
-      console.log(client.onConfigurationLoaded.subscriptions);
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
-
-          // the client is initialized now, so set an expiry on the cache item
-          let item: CacheItem = Cache.current.items[0];
-          item.expires = new Date();
-          item.expires.setDate(item.expires.getDate() - 1); // set to be expired
-          item.revision--;
-
-          getCobHitIndex = 2;
-
-          client.checkCacheTimeouts();
-          expect(getCobSpy).toHaveBeenCalledTimes(2); // shows that the config is reloaded.
-          expect(emittedError).toBeTruthy();
-          expect(emittedError.message).toEqual("subsequent-error");
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
+    it("init: successful happy path initialization, loads application and config object.", function(done: () => void): void {
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
         });
-  });*/
 
-  it("get: get item from cache, item exists.", function(done: () => void): void {
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
 
-      let client: ClocoClient = new ClocoClient(options);
+        client.init()
+            .then(() => {
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(1);
+                expect(Cache.current.items[0].value).toEqual(cob.configurationData);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
 
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+    it("init: successful initialization, loads application and config object, cache on disk.", function(done: () => void): void {
 
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
+        options.useDiskCaching = true;
+        let filenames: string[] = [];
 
-          // retrieve the cache item by the key (objectIdentifier).
-          let data: any = client.get<any>("test-cob");
-          expect(data).toEqual(cob.configurationData);
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
         });
-  });
 
-  it("get: get item from cache, item does not exist.", function(done: () => void): void {
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
+            .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
+                filenames.push(f);
+                callback(undefined);
+            });
 
-      let client: ClocoClient = new ClocoClient(options);
+        client.init()
+            .then(() => {
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(1);
+                expect(Cache.current.items[0].value).toEqual(cob.configurationData);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+                expect(filenames.length).toEqual(2);
+                expect(filenames[0]).toEqual(`${process.env.HOME}/.cloco/cache/application_application`);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
 
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+    it("init: successful initialization, loads application and config object, fail to cache on disk.", function(done: () => void): void {
 
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
+        options.useDiskCaching = true;
+        let filenames: string[] = [];
 
-          // retrieve the cache item by the key (objectIdentifier).
-          let data: any = client.get<any>("unknown-cob");
-          expect(data).toEqual(undefined);
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
         });
-  });
 
-  it("get: get encypted item from cache, item exists, decrypts successfully.", function(done: () => void): void {
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
+            .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
+                filenames.push(f);
+                callback(new Error("disk-error"));
+            });
+        let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(false);
 
-      options.encryptor = aes;
-      let originalData: any = cob.configurationData;
-      cob.configurationData = aes.encrypt(JSON.stringify(originalData)); // encrypt the data packet.
-      let client: ClocoClient = new ClocoClient(options);
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("disk-error");
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                expect(writeFileSpy).toHaveBeenCalledTimes(1);
+                expect(fileExistsSpy).toHaveBeenCalledTimes(0);
+                expect(filenames.length).toEqual(1);
+                expect(filenames[0]).toEqual(`${process.env.HOME}/.cloco/cache/application_application`);
+                done();
+            });
+    });
 
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
-
-          // retrieve the cache item by the key (objectIdentifier).
-          let data: any = client.get<any>("test-cob");
-          expect(data).toEqual(originalData);
-          done();
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
+    it("init: failure to load application, error.", function(done: () => void): void {
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
         });
-  });
 
-  it("put: update item in cache, success.", function(done: () => void): void {
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
+            .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
 
-      let client: ClocoClient = new ClocoClient(options);
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("app-error");
+                expect(client.app).toEqual(undefined);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
 
-      let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
-      updatedCob.configurationData.foo = "baa";
-      updatedCob.revisionNumber++;
+    it("init: failure to load application, load from disk, success.", function(done: () => void): void {
 
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
+        options.useDiskCaching = true;
+        let filenames: string[] = [];
 
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
 
-          // update the item.
-          client.put<any>("test-cob", updatedCob.configurationData)
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
+            .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
+        let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
+            .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
+                callback(undefined, JSON.stringify(app));
+            });
+        let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
+            .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
+                filenames.push(f);
+                callback(undefined);
+            });
+
+        client.init()
+            .then(() => {
+                expect(client.app.applicationIdentifier).toEqual(app.applicationIdentifier);
+                expect(Cache.current.items.length).toEqual(1);
+                expect(Cache.current.items[0].value).toEqual(cob.configurationData);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+                expect(fileExistsSpy).toHaveBeenCalledTimes(1);
+                expect(readFileSpy).toHaveBeenCalledTimes(1);
+                expect(filenames.length).toEqual(1);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("init: failure to load application, load from disk, file not found, fail.", function(done: () => void): void {
+
+        options.useDiskCaching = true;
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
+            .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(false);
+        let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
+            .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
+                callback(undefined, JSON.stringify(app));
+            });
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("app-error");
+                expect(client.app).toEqual(undefined);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                expect(fileExistsSpy).toHaveBeenCalledTimes(1);
+                expect(readFileSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
+
+    it("init: failure to load application, load from disk, invalid JSON, fail.", function(done: () => void): void {
+
+        options.useDiskCaching = true;
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
+            .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
+        let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
+            .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
+                callback(undefined, "{invalid-JSON]");
+            });
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("Unexpected token i in JSON at position 1");
+                expect(client.app).toEqual(undefined);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                expect(fileExistsSpy).toHaveBeenCalledTimes(1);
+                expect(readFileSpy).toHaveBeenCalledTimes(1);
+                done();
+            });
+    });
+
+    it("init: failure to load application, load from disk, disk read fails, fail.", function(done: () => void): void {
+
+        options.useDiskCaching = true;
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication")
+            .and.returnValue(ApiClientMock.getApplication(app, new Error("app-error")));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
+        let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
+            .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
+                callback(new Error("cat-error"), undefined);
+            });
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("cat-error");
+                expect(client.app).toEqual(undefined);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                expect(fileExistsSpy).toHaveBeenCalledTimes(1);
+                expect(readFileSpy).toHaveBeenCalledTimes(1);
+                done();
+            });
+    });
+
+    it("init: failure to load configuration, error.", function(done: () => void): void {
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject")
+            .and.returnValue(ApiClientMock.getConfigObject(cob, new Error("cob-error")));
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("cob-error");
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+                done();
+            });
+    });
+
+    it("init: environment not found in application, error.", function(done: () => void): void {
+
+        options.environment = "unknown";
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("The environment 'unknown' does not exist in application.");
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
+
+    it("init: no application returned by api, error.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(undefined));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("The environment 'test' does not exist in application.");
+                expect(client.app).toEqual(undefined);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
+
+    it("init: no environments in application returned by api, error.", function(done: () => void): void {
+
+        app.environments = undefined;
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("The environment 'test' does not exist in application.");
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
+
+    it("init: empty environments array in application returned by api, error.", function(done: () => void): void {
+
+        app.environments = [];
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("The environment 'test' does not exist in application.");
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
+
+    it("init: empty environments option, error.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        options.environment = "";
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("The environment '' does not exist in application.");
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(0);
+                done();
+            });
+    });
+
+    it("init: failure to load config, use disk cache, success.", function(done: () => void): void {
+
+        options.useDiskCaching = true;
+        let filenames: string[] = [];
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject")
+            .and.returnValue(ApiClientMock.getConfigObject(cob, new Error("cob-error")));
+        let fileExistsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
+        let readFileSpy: jasmine.Spy = spyOn(fs, "readFile")
+            .and.callFake((f: string, enc: string, callback: (err: Error, data: string) => void): void => {
+                callback(undefined, JSON.stringify(cob));
+            });
+        let writeFileSpy: jasmine.Spy = spyOn(fs, "writeFile")
+            .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
+                filenames.push(f);
+                callback(undefined);
+            });
+
+        client.init()
+            .then(() => {
+                expect(client.app.applicationIdentifier).toEqual(app.applicationIdentifier);
+                expect(Cache.current.items.length).toEqual(1);
+                expect(Cache.current.items[0].value).toEqual(cob.configurationData);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+                expect(fileExistsSpy).toHaveBeenCalledTimes(1);
+                expect(readFileSpy).toHaveBeenCalledTimes(1);
+                expect(writeFileSpy).toHaveBeenCalledTimes(1);
+                expect(filenames.length).toEqual(1);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("init: failure to decrypt config, fail.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+        spyOn(client, "decryptAndDecode").and.callFake((): void => {
+            throw new Error("decrypt-error");
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                fail("expect error to have been thrown.");
+                done();
+            })
+            .catch((e: Error) => {
+                expect(e.message).toEqual("decrypt-error");
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+                done();
+            });
+    });
+
+    it("init: load config, no item added to cache, success.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+        spyOn(client, "checkCacheTimeouts").and.callFake((): void => {
+            return;
+        });
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let addItemSpy: jasmine.Spy = spyOn(Cache.current, "addItem").and.returnValue(undefined);
+
+        client.init()
+            .then(() => {
+                expect(client.app).toEqual(app);
+                expect(Cache.current.items.length).toEqual(0);
+                expect(getAppSpy).toHaveBeenCalledTimes(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+                expect(addItemSpy).toHaveBeenCalledTimes(1);
+                done();
+            })
+            .catch((e: Error) => {
+                fail("expect error to have been thrown.");
+                done();
+            });
+    });
+
+    it("checkCacheTimeouts: cache item expired, reloads the config.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // the client is initialized now, so set an expiry on the cache item
+                let item: CacheItem = Cache.current.items[0];
+                item.expires = new Date();
+                item.expires.setDate(item.expires.getDate() - 1); // set to be expired
+
+                client.checkCacheTimeouts();
+                expect(getCobSpy).toHaveBeenCalledTimes(2);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("checkCacheTimeouts: cache item not expired, reload config, no update.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let dispatchSpy: jasmine.Spy = spyOn(client.onConfigurationLoaded, "dispatch").and.callThrough();
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // the client is initialized now, so set an expiry on the cache item
+                let item: CacheItem = Cache.current.items[0];
+                item.expires = new Date();
+                item.expires.setDate(item.expires.getDate() - 1); // set to be expired
+
+                spyOn(Cache.current, "addItem").and.returnValue(undefined); // no item added to cache
+
+                client.checkCacheTimeouts();
+                expect(getCobSpy).toHaveBeenCalledTimes(2); // shows that the config loaded twice.
+                expect(dispatchSpy).toHaveBeenCalledTimes(1); // shows that the config published once.
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("checkCacheTimeouts: cache item not expired, no reload of config.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // the client is initialized now, so set an expiry on the cache item
+                let item: CacheItem = Cache.current.items[0];
+                item.expires = new Date();
+                item.expires.setDate(item.expires.getDate() + 1); // set to be expired
+
+                client.checkCacheTimeouts();
+                expect(getCobSpy).toHaveBeenCalledTimes(1); // shows that the config is not reloaded.
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    /*it("checkCacheTimeouts: cache item expired, reloads config, error.", function(done: () => void): void {
+
+        Logger.log = bunyan.createLogger({
+              level: "debug",
+              name: "cloco-node-client",
+          });
+
+        let client: ClocoClient = new ClocoClient(options);
+        let emittedError: Error;
+        client.onError.subscribe((sender: ClocoClient, e: Error): void => {
+            console.log(e);
+            emittedError = e;
+        });
+
+        let func: any = (sender: ClocoClient, value: CacheItem): void => {
+          console.log(value);
+          console.log(`Hit index: ${getCobHitIndex}`);
+          if (getCobHitIndex === 2) {
+            throw new Error("subsequent-error");
+          }
+        };
+
+        // set up a subscription to throw an error next time config is loaded
+        client.onConfigurationLoaded.subscribe(func);
+        console.log(client.onConfigurationLoaded.subscriptions);
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
           .then(() => {
             expect(Cache.current.items.length).toEqual(1);
-            expect(Cache.current.items[0].value).toEqual(updatedCob.configurationData);
-            expect(Cache.current.items[0].revision).toEqual(updatedCob.revisionNumber);
-            expect(putCobSpy).toHaveBeenCalledTimes(1);
-            done();
-          });
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
-        });
-  });
+            expect(getCobSpy).toHaveBeenCalledTimes(1);
 
-  it("put: update item in cache, unknown cob key, errors.", function(done: () => void): void {
+            // the client is initialized now, so set an expiry on the cache item
+            let item: CacheItem = Cache.current.items[0];
+            item.expires = new Date();
+            item.expires.setDate(item.expires.getDate() - 1); // set to be expired
+            item.revision--;
 
-      let client: ClocoClient = new ClocoClient(options);
+            getCobHitIndex = 2;
 
-      let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
-      updatedCob.configurationData.foo = "baa";
-      updatedCob.revisionNumber++;
-
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
-
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
-
-          // update the item.
-          client.put<any>("unknown-cob", updatedCob.configurationData)
-          .then(() => {
-            fail("expect exception to be raised");
+            client.checkCacheTimeouts();
+            expect(getCobSpy).toHaveBeenCalledTimes(2); // shows that the config is reloaded.
+            expect(emittedError).toBeTruthy();
+            expect(emittedError.message).toEqual("subsequent-error");
             done();
           })
           .catch((e: Error) => {
-            expect(e.message).toEqual("Config object metadata for 'unknown-cob' not found in application.");
-            expect(Cache.current.items[0].value).toEqual(cob.configurationData);
-            expect(Cache.current.items[0].revision).toEqual(cob.revisionNumber);
-            expect(putCobSpy).toHaveBeenCalledTimes(0);
+            console.log(e);
+            fail("error not expected");
             done();
           });
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
-        });
-  });
+    });*/
 
-  it("put: update item in cache, config objects missing, errors.", function(done: () => void): void {
+    it("get: get item from cache, item exists.", function(done: () => void): void {
 
-      let client: ClocoClient = new ClocoClient(options);
+        let client: ClocoClient = new ClocoClient(options);
 
-      let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
-      updatedCob.configurationData.foo = "baa";
-      updatedCob.revisionNumber++;
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
 
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
 
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
+                // retrieve the cache item by the key (objectIdentifier).
+                let data: any = client.get<any>("test-cob");
+                expect(data).toEqual(cob.configurationData);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
 
-          // update the item.
-          client.app.configObjects = undefined; // corrupt the metadata.
-          client.put<any>("unknown-cob", updatedCob.configurationData)
-          .then(() => {
-            fail("expect exception to be raised");
-            done();
-          })
-          .catch((e: Error) => {
-            expect(e.message).toEqual("Config object metadata for 'unknown-cob' not found in application.");
-            expect(Cache.current.items[0].value).toEqual(cob.configurationData);
-            expect(Cache.current.items[0].revision).toEqual(cob.revisionNumber);
-            expect(putCobSpy).toHaveBeenCalledTimes(0);
-            done();
-          });
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
-        });
-  });
+    it("get: get item from cache, item does not exist.", function(done: () => void): void {
 
-  it("put: update encrypted item in cache, success.", function(done: () => void): void {
+        let client: ClocoClient = new ClocoClient(options);
 
-      options.encryptor = aes;
-      cob.configurationData = aes.encrypt(JSON.stringify(cob.configurationData)); // encrypt the data packet.
-      let client: ClocoClient = new ClocoClient(options);
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
 
-      let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
-      let updatedData: any = { foo: "baa" };
-      updatedCob.configurationData = aes.encrypt(JSON.stringify(updatedData)); // encrypt the data packet.
-      updatedCob.revisionNumber++;
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
 
-      let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
-      let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
-      let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
+                // retrieve the cache item by the key (objectIdentifier).
+                let data: any = client.get<any>("unknown-cob");
+                expect(data).toEqual(undefined);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
 
-      client.init()
-        .then(() => {
-          expect(Cache.current.items.length).toEqual(1);
-          expect(getCobSpy).toHaveBeenCalledTimes(1);
+    it("get: get encypted item from cache, item exists, decrypts successfully.", function(done: () => void): void {
 
-          // update the item.
-          client.put<any>("test-cob", updatedData)
-          .then(() => {
-            expect(Cache.current.items.length).toEqual(1);
-            expect(Cache.current.items[0].value).toEqual(updatedData);
-            expect(Cache.current.items[0].revision).toEqual(updatedCob.revisionNumber);
-            expect(putCobSpy).toHaveBeenCalledTimes(1);
-            done();
-          });
-        })
-        .catch((e: Error) => {
-          console.log(e);
-          fail("error not expected");
-          done();
-        });
-  });
+        options.encryptor = aes;
+        let originalData: any = cob.configurationData;
+        cob.configurationData = aes.encrypt(JSON.stringify(originalData)); // encrypt the data packet.
+        let client: ClocoClient = new ClocoClient(options);
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // retrieve the cache item by the key (objectIdentifier).
+                let data: any = client.get<any>("test-cob");
+                expect(data).toEqual(originalData);
+                done();
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("put: update item in cache, success.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+
+        let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
+        updatedCob.configurationData.foo = "baa";
+        updatedCob.revisionNumber++;
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // update the item.
+                client.put<any>("test-cob", updatedCob.configurationData)
+                    .then(() => {
+                        expect(Cache.current.items.length).toEqual(1);
+                        expect(Cache.current.items[0].value).toEqual(updatedCob.configurationData);
+                        expect(Cache.current.items[0].revision).toEqual(updatedCob.revisionNumber);
+                        expect(putCobSpy).toHaveBeenCalledTimes(1);
+                        done();
+                    });
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("put: update item in cache, unknown cob key, errors.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+
+        let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
+        updatedCob.configurationData.foo = "baa";
+        updatedCob.revisionNumber++;
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // update the item.
+                client.put<any>("unknown-cob", updatedCob.configurationData)
+                    .then(() => {
+                        fail("expect exception to be raised");
+                        done();
+                    })
+                    .catch((e: Error) => {
+                        expect(e.message).toEqual("Config object metadata for 'unknown-cob' not found in application.");
+                        expect(Cache.current.items[0].value).toEqual(cob.configurationData);
+                        expect(Cache.current.items[0].revision).toEqual(cob.revisionNumber);
+                        expect(putCobSpy).toHaveBeenCalledTimes(0);
+                        done();
+                    });
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("put: update item in cache, config objects missing, errors.", function(done: () => void): void {
+
+        let client: ClocoClient = new ClocoClient(options);
+
+        let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
+        updatedCob.configurationData.foo = "baa";
+        updatedCob.revisionNumber++;
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // update the item.
+                client.app.configObjects = undefined; // corrupt the metadata.
+                client.put<any>("unknown-cob", updatedCob.configurationData)
+                    .then(() => {
+                        fail("expect exception to be raised");
+                        done();
+                    })
+                    .catch((e: Error) => {
+                        expect(e.message).toEqual("Config object metadata for 'unknown-cob' not found in application.");
+                        expect(Cache.current.items[0].value).toEqual(cob.configurationData);
+                        expect(Cache.current.items[0].revision).toEqual(cob.revisionNumber);
+                        expect(putCobSpy).toHaveBeenCalledTimes(0);
+                        done();
+                    });
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
+
+    it("put: update encrypted item in cache, success.", function(done: () => void): void {
+
+        options.encryptor = aes;
+        cob.configurationData = aes.encrypt(JSON.stringify(cob.configurationData)); // encrypt the data packet.
+        let client: ClocoClient = new ClocoClient(options);
+
+        let updatedCob: ConfigObjectWrapper = JSON.parse(JSON.stringify(cob));
+        let updatedData: any = { foo: "baa" };
+        updatedCob.configurationData = aes.encrypt(JSON.stringify(updatedData)); // encrypt the data packet.
+        updatedCob.revisionNumber++;
+
+        let getAppSpy: jasmine.Spy = spyOn(ApiClient, "getApplication").and.returnValue(ApiClientMock.getApplication(app));
+        let getCobSpy: jasmine.Spy = spyOn(ApiClient, "getConfigObject").and.returnValue(ApiClientMock.getConfigObject(cob));
+        let putCobSpy: jasmine.Spy = spyOn(ApiClient, "putConfigObject").and.returnValue(ApiClientMock.putConfigObject(updatedCob));
+
+        client.init()
+            .then(() => {
+                expect(Cache.current.items.length).toEqual(1);
+                expect(getCobSpy).toHaveBeenCalledTimes(1);
+
+                // update the item.
+                client.put<any>("test-cob", updatedData)
+                    .then(() => {
+                        expect(Cache.current.items.length).toEqual(1);
+                        expect(Cache.current.items[0].value).toEqual(updatedData);
+                        expect(Cache.current.items[0].revision).toEqual(updatedCob.revisionNumber);
+                        expect(putCobSpy).toHaveBeenCalledTimes(1);
+                        done();
+                    });
+            })
+            .catch((e: Error) => {
+                console.log(e);
+                fail("error not expected");
+                done();
+            });
+    });
 });

--- a/src/cloco-client.spec.ts
+++ b/src/cloco-client.spec.ts
@@ -6,6 +6,7 @@
  */
 import * as bunyan from "bunyan";
 import * as fs from "fs";
+import * as ini from "ini";
 import { JwtGenerator } from "./test/jwt-generator";
 import { AesEncryptor } from "./encryption/aes-encryptor";
 import { ApiClientMock } from "./test/api-client-mock";
@@ -20,6 +21,7 @@ import { Settings } from "./settings";
 
 describe("ClocoClient unit tests", function(): void {
 
+    let config: any;
     let options: IOptions;
     let configSpy: jasmine.Spy;
     let app: ClocoApp;
@@ -29,8 +31,8 @@ describe("ClocoClient unit tests", function(): void {
 
     beforeAll(function(done: () => void): void {
         Logger.init({});
-        configSpy = spyOn(Settings, "readFileContent").and.callFake((path: string) => {
-            return "file-content";
+        configSpy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
         });
         done();
     });
@@ -48,6 +50,21 @@ describe("ClocoClient unit tests", function(): void {
         options.application = "application";
         options.environment = "test";
         options.cacheCheckInterval = -1;
+
+        config = {
+            credentials: {
+                cloco_client_key: "api-key",
+                cloco_client_secret: "api-secret",
+            },
+            preferences: {
+                application: "config-application",
+                environment: "config-environment",
+                subscription: "config-subscription",
+            },
+            settings: {
+                url: "cloco-url",
+            },
+        };
 
         app = {
             applicationIdentifier: "test-app",
@@ -118,7 +135,7 @@ describe("ClocoClient unit tests", function(): void {
 
         options.environment = "";
 
-        let envSpy: jasmine.Spy = spyOn(Settings, "getDefaultEnvironment").and.callFake((): void => {
+        let envSpy: jasmine.Spy = spyOn(Settings, "getConfigFilePath").and.callFake((): void => {
             throw new Error("unit-test-error");
         });
 

--- a/src/file-system.ts
+++ b/src/file-system.ts
@@ -66,19 +66,31 @@ export class FileSystem {
     }
 
     /**
+     * Ensures that the local config directories exist.
+     */
+    public static ensureDirectory(path: string): void {
+        Logger.log.debug("FileSystem.ensureDirectory: start.");
+        if (!fs.existsSync(path)) {
+            Logger.log.debug(`FileSystem.ensureDirectory: creating local folder '${path}'.`);
+            fs.mkdir(path);
+        }
+        Logger.log.debug("FileSystem.ensureDirectory: end.");
+    }
+
+    /**
      * Returns the user home path.
      * @return {string} The user home path.
      */
     public static getUserHome(): string {
-      Logger.log.debug(`FileSystem.getUserHome: start.`);
+        Logger.log.debug(`FileSystem.getUserHome: start.`);
 
-      if (FileSystem.getPlatform() === "win32") {
-        Logger.log.debug(`FileSystem.getUserHome: returning win32 home directory.`);
-        return process.env.USERPROFILE;
-      } else {
-        Logger.log.debug(`FileSystem.getUserHome: returning default home directory.`);
-        return process.env.HOME;
-      }
+        if (FileSystem.getPlatform() === "win32") {
+            Logger.log.debug(`FileSystem.getUserHome: returning win32 home directory.`);
+            return process.env.USERPROFILE;
+        } else {
+            Logger.log.debug(`FileSystem.getUserHome: returning default home directory.`);
+            return process.env.HOME;
+        }
     }
 
     /**
@@ -86,6 +98,6 @@ export class FileSystem {
      * @return {string} The platform.
      */
     private static getPlatform(): string {
-      return process.platform;
+        return process.platform;
     }
 }

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -3,6 +3,7 @@
  *   Copyright (c) 345 Systems LLP 2016, all rights reserved.
  */
 import * as fs from "fs";
+import * as ini from "ini";
 import { Settings } from "./settings";
 import { IOptions } from "./types/ioptions";
 import { Logger } from "./logging/logger";
@@ -12,335 +13,198 @@ import { Tokens } from "./types/tokens";
 
 describe("Settings unit tests", function(): void {
 
-  // initialize.
-  beforeAll(function(): void {
-      Logger.init({});
-  });
-
-  it("setDefaults: empty options set everything to default.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      let options: IOptions = {};
-
-      Settings.setDefaults(options);
-
-      expect(options.useEncryption).toEqual(false);
-      expect(options.encryptor).toBeTruthy("options.encryptor");
-      expect(options.encryptor instanceof PassthroughEncryptor).toBeTruthy("options.encryptor instanceof PassthroughEncryptor");
-      expect(options.url).toEqual("file-content");
-      expect(options.subscription).toEqual("file-content");
-      expect(options.application).toEqual("file-content");
-      expect(options.environment).toEqual("file-content");
-      expect(options.cacheCheckInterval).toEqual(60000);
-      expect(options.tokens).toBeTruthy("options.tokens");
-      expect(options.tokens instanceof Tokens).toBeTruthy("options.tokens instanceof Tokens");
-  });
-
-  it("setDefaults: default url set blank, defaults to cloco prod value.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getDefaultUrl").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-
-      Settings.setDefaults(options);
-
-      expect(options.url).toEqual("https://api.cloco.io");
-  });
-
-  it("setDefaults: encryptor supplied, marks as supporting encryption.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      let options: IOptions = {};
-      options.encryptor = new PassthroughEncryptor();
-
-      Settings.setDefaults(options);
-
-      expect(options.useEncryption).toEqual(true);
-  });
-
-  it("setDefaults: default subscription empty, raises error.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getDefaultSubscription").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-
-      try {
-          Settings.setDefaults(options);
-          fail("expect failure because of no default subscription.");
-      } catch (e) {
-          expect(e).toBeTruthy();
-          expect(e instanceof SettingsError).toBeTruthy();
-          expect(e.setting).toEqual("options.subscription");
-      }
-  });
-
-  it("setDefaults: default subscription empty, config file not available, raises error.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return false;
-      });
-
-      spyOn(Settings, "getDefaultSubscription").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-
-      try {
-          Settings.setDefaults(options);
-          fail("expect failure because of no default subscription.");
-      } catch (e) {
-          expect(e).toBeTruthy();
-          expect(e instanceof SettingsError).toBeTruthy();
-          expect(e.setting).toEqual("options.subscription");
-      }
-  });
-
-  it("setDefaults: default application empty, raises error.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getDefaultApplication").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-
-      try {
-          Settings.setDefaults(options);
-          fail("expect failure because of no default application.");
-      } catch (e) {
-          expect(e).toBeTruthy();
-          expect(e instanceof SettingsError).toBeTruthy();
-          expect(e.setting).toEqual("options.application");
-      }
-  });
-
-  it("setDefaults: default environment empty, raises error.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getDefaultEnvironment").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-
-      try {
-          Settings.setDefaults(options);
-          fail("expect failure because of no default environment.");
-      } catch (e) {
-          expect(e).toBeTruthy();
-          expect(e instanceof SettingsError).toBeTruthy();
-          expect(e.setting).toEqual("options.environment");
-      }
-  });
-
-  it("setDefaults: stored bearer token empty, raises error.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getBearerToken").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-
-      try {
-          Settings.setDefaults(options);
-          fail("expect failure because of no access token.");
-      } catch (e) {
-          expect(e).toBeTruthy();
-          expect(e instanceof SettingsError).toBeTruthy();
-          expect(e.setting).toEqual("options.tokens.accessToken");
-      }
-  });
-
-  it("setDefaults: stored refresh token empty, raises error.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getRefreshToken").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-
-      try {
-          Settings.setDefaults(options);
-          fail("expect failure because of no refresh token.");
-      } catch (e) {
-          expect(e).toBeTruthy();
-          expect(e instanceof SettingsError).toBeTruthy();
-          expect(e.setting).toEqual("options.tokens.refreshToken");
-      }
-  });
-
-  it("setDefaults: tokens supplied, no error initializing tokens.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getRefreshToken").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-      options.tokens = { accessToken: "token", refreshToken: "refresh" };
-      Settings.setDefaults(options);
-      expect(options.credentials).toBeFalsy();
-  });
-
-  it("setDefaults: credentials supplied, no error initializing tokens.", function(): void {
-
-      let spy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
-        return "file-content";
-      });
-
-      spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      spyOn(fs, "existsSync").and.callFake((path: string) => {
-        return true;
-      });
-
-      spyOn(Settings, "getRefreshToken").and.callFake((path: string) => {
-        return "";
-      });
-
-      let options: IOptions = {};
-      options.credentials = { key: "key", secret: "secret" };
-      Settings.setDefaults(options);
-      expect(options.credentials).toBeTruthy();
-      expect(options.tokens).toBeTruthy();
-      expect(options.tokens.refreshToken).toBeFalsy();
-  });
-
-  it("storeBearerToken: credentials supplied, no error initializing tokens.", function(): void {
-
-      let mkdirSpy: jasmine.Spy = spyOn(fs, "mkdir").and.callFake((path: string) => {
-        return;
-      });
-
-      let existsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.returnValue(true);
-
-      let writeSpy: jasmine.Spy = spyOn(fs, "writeFile")
-        .and.callFake((f: string, data: string, enc: string, callback: (err: Error) => void): any => {
-          callback(undefined);
-      });
-
-      Settings.storeBearerToken("token");
-
-      expect(mkdirSpy).toHaveBeenCalledTimes(0);
-      expect(existsSpy).toHaveBeenCalledTimes(0);
-      expect(writeSpy).toHaveBeenCalledTimes(1);
-  });
+    let config: any;
+    let options: IOptions;
+
+    // initialize.
+    beforeAll(function(): void {
+        Logger.init({});
+    });
+
+    beforeEach(function(): void {
+        options = {};
+        config = {
+            credentials: {
+                cloco_client_key: "api-key",
+                cloco_client_secret: "api-secret",
+            },
+            preferences: {
+                application: "application",
+                environment: "environment",
+                subscription: "subscription",
+            },
+            settings: {
+                url: "cloco-url",
+            },
+        };
+    });
+
+    it("setDefaults: empty options set everything to default.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return true;
+        });
+
+        Settings.setDefaults(options);
+
+        expect(options.useEncryption).toEqual(false);
+        expect(options.encryptor).toBeTruthy("options.encryptor");
+        expect(options.encryptor instanceof PassthroughEncryptor).toBeTruthy("options.encryptor instanceof PassthroughEncryptor");
+        expect(options.url).toEqual("cloco-url");
+        expect(options.subscription).toEqual("subscription");
+        expect(options.application).toEqual("application");
+        expect(options.environment).toEqual("environment");
+        expect(options.cacheCheckInterval).toEqual(60000);
+        expect(options.credentials).toBeTruthy("options.credentials");
+        expect(options.credentials.key).toEqual("api-key");
+        expect(options.credentials.secret).toEqual("api-secret");
+        expect(options.tokens).toBeTruthy("options.tokens");
+        expect(options.tokens instanceof Tokens).toBeTruthy("options.tokens instanceof Tokens");
+    });
+
+    it("setDefaults: default url set blank, defaults to cloco prod value.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return true;
+        });
+
+        config.settings.url = "";
+
+        Settings.setDefaults(options);
+
+        expect(options.url).toEqual("https://api.cloco.io");
+    });
+
+    it("setDefaults: encryptor supplied, marks as supporting encryption.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return true;
+        });
+
+        options.encryptor = new PassthroughEncryptor();
+
+        Settings.setDefaults(options);
+
+        expect(options.useEncryption).toEqual(true);
+    });
+
+    it("setDefaults: default subscription empty, raises error.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return true;
+        });
+
+        config.preferences.subscription = "";
+
+        try {
+            Settings.setDefaults(options);
+            fail("expect failure because of no default subscription.");
+        } catch (e) {
+            expect(e).toBeTruthy();
+            expect(e instanceof SettingsError).toBeTruthy();
+            expect(e.setting).toEqual("options.subscription");
+        }
+    });
+
+    it("setDefaults: default subscription empty, config file not available, raises error.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return false;
+        });
+
+        try {
+            Settings.setDefaults(options);
+            fail("expect failure because of no default subscription.");
+        } catch (e) {
+            expect(e).toBeTruthy();
+            expect(e instanceof SettingsError).toBeTruthy();
+            expect(e.setting).toEqual("options.subscription");
+        }
+    });
+
+    it("setDefaults: default application empty, raises error.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return true;
+        });
+
+        config.preferences.application = "";
+
+        try {
+            Settings.setDefaults(options);
+            fail("expect failure because of no default application.");
+        } catch (e) {
+            expect(e).toBeTruthy();
+            expect(e instanceof SettingsError).toBeTruthy();
+            expect(e.setting).toEqual("options.application");
+        }
+    });
+
+    it("setDefaults: default environment empty, raises error.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return true;
+        });
+
+        config.preferences.environment = "";
+
+        try {
+            Settings.setDefaults(options);
+            fail("expect failure because of no default environment.");
+        } catch (e) {
+            expect(e).toBeTruthy();
+            expect(e instanceof SettingsError).toBeTruthy();
+            expect(e.setting).toEqual("options.environment");
+        }
+    });
+
+    it("setDefaults: credentials supplied, no error initializing tokens.", function(): void {
+
+        let iniSpy: jasmine.Spy = spyOn(ini, "parse").and.callFake((path: string) => {
+            return config;
+        });
+
+        let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
+            return true;
+        });
+
+        config.credentials.cloco_client_key = "";
+        config.credentials.cloco_client_secret = "";
+
+        options.credentials = { key: "key", secret: "secret" };
+        Settings.setDefaults(options);
+        expect(options.credentials).toBeTruthy();
+        expect(options.credentials.key).toEqual("key");
+        expect(options.credentials.secret).toEqual("secret");
+        expect(options.tokens).toBeTruthy();
+        expect(options.tokens.refreshToken).toBeFalsy();
+    });
 });

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -49,6 +49,10 @@ describe("Settings unit tests", function(): void {
             return true;
         });
 
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
+        });
+
         Settings.setDefaults(options);
 
         expect(options.useEncryption).toEqual(false);
@@ -76,6 +80,10 @@ describe("Settings unit tests", function(): void {
             return true;
         });
 
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
+        });
+
         config.settings.url = "";
 
         Settings.setDefaults(options);
@@ -93,6 +101,10 @@ describe("Settings unit tests", function(): void {
             return true;
         });
 
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
+        });
+
         options.encryptor = new PassthroughEncryptor();
 
         Settings.setDefaults(options);
@@ -108,6 +120,10 @@ describe("Settings unit tests", function(): void {
 
         let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
             return true;
+        });
+
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
         });
 
         config.preferences.subscription = "";
@@ -132,6 +148,10 @@ describe("Settings unit tests", function(): void {
             return false;
         });
 
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
+        });
+
         try {
             Settings.setDefaults(options);
             fail("expect failure because of no default subscription.");
@@ -150,6 +170,10 @@ describe("Settings unit tests", function(): void {
 
         let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
             return true;
+        });
+
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
         });
 
         config.preferences.application = "";
@@ -174,6 +198,10 @@ describe("Settings unit tests", function(): void {
             return true;
         });
 
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
+        });
+
         config.preferences.environment = "";
 
         try {
@@ -194,6 +222,10 @@ describe("Settings unit tests", function(): void {
 
         let fsSpy: jasmine.Spy = spyOn(fs, "existsSync").and.callFake((path: string) => {
             return true;
+        });
+
+        let readSpy: jasmine.Spy = spyOn(fs, "readFileSync").and.callFake((path: string) => {
+            return "some-config";
         });
 
         config.credentials.cloco_client_key = "";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,7 +30,7 @@ export class Settings {
         // check for local settings
         if (fs.existsSync(Settings.getConfigFilePath())) {
 
-            let config: any = ini.parse(Settings.getConfigFilePath());
+            let config: any = ini.parse(fs.readFileSync(Settings.getConfigFilePath(), "utf-8"));
 
             // load the url from config else use the default cloco one.
             options.url = options.url || config.settings.url;

--- a/src/types/clocoapp.ts
+++ b/src/types/clocoapp.ts
@@ -175,7 +175,7 @@ export class ClocoAppCoreDetails {
      * Indicates whether this is the default app in the subscription.
      * @type {boolean}
      */
-    public isDefault: boolean;
+    public isFavorite: boolean;
 }
 
 /**


### PR DESCRIPTION
Updates the client to use the ini file settings as set by the cloco-cli.  This is used to find default values if they are not passed in via the options.
No longer supports refresh tokens, requests for access tokens are made using API credentials.
Updates to affected unit tests.
Supports change in app from isDefault to isFavorite.